### PR TITLE
Refine CLI with argparse and CI setup

### DIFF
--- a/.github/workflows/01-lint-format.yml
+++ b/.github/workflows/01-lint-format.yml
@@ -1,0 +1,39 @@
+name: Lint & Format
+on: [push, pull_request]
+jobs:
+  lint-format:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [python, javascript]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        if: matrix.language == 'python'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install Py Lint Tools
+        if: matrix.language == 'python'
+        run: pip install flake8 black isort
+      - name: Run Python Linters
+        if: matrix.language == 'python'
+        run: |
+          flake8 .
+          isort --check-only .
+          black --check .
+
+      - name: Setup Node
+        if: matrix.language == 'javascript'
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install JS Lint Tools
+        if: matrix.language == 'javascript' && hashFiles('package.json') != ''
+        run: npm install --no-audit --no-fund
+      - name: Run JS Linters
+        if: matrix.language == 'javascript' && hashFiles('package.json') != ''
+        run: |
+          npm run lint
+          npm run format:check

--- a/.github/workflows/02-tests.yml
+++ b/.github/workflows/02-tests.yml
@@ -1,0 +1,31 @@
+name: Test Suite
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        language: [python, javascript]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Python Tests
+        if: matrix.language == 'python'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - if: matrix.language == 'python'
+        run: |
+          pip install pytest
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pytest --maxfail=1 --disable-warnings -q
+
+      - name: JavaScript Tests
+        if: matrix.language == 'javascript'
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - if: matrix.language == 'javascript' && hashFiles('package.json') != ''
+        run: |
+          npm install --no-audit --no-fund
+          npm test -- --coverage

--- a/.github/workflows/03-docs.yml
+++ b/.github/workflows/03-docs.yml
@@ -1,0 +1,21 @@
+name: Docs Preview & Link Check
+on:
+  push:
+    paths:
+      - 'docs/**'
+      - 'README.md'
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rojopolis/spellcheck-github-actions@v0
+        with:
+          config_path: spellcheck.yaml
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          pip install linkchecker
+          linkchecker README.md docs/ || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,12 +3,16 @@
 This project uses lightweight command line utilities to copy files into Markdown for LLM conversations. It may evolve into a workflow-based CLI, so clear instructions are important for contributors and future LLM agents.
 
 ## Overview
-- `f2clipboard.py` collects files from a chosen directory and copies their contents to the clipboard in a formatted block.
+- `f2clipboard.py` collects files from a chosen directory and copies their contents to the clipboard in a formatted block. The CLI supports:
+
+- `-d, --directory` – directory to search
+- `-p, --pattern` – glob pattern for files (default `*`)
+- `-y, --yes` – select all matching files without interactive prompts
 - See the [README](README.md) for installation and the project roadmap.
 
 ## Setup
 1. Ensure Python 3.x is installed.
-2. Install dependencies with `pip install clipboard`.
+2. Install dependencies with `pip install -e .` (installs `clipboard` and sets up the package for development).
 3. Optionally create a virtual environment for isolation.
 4. Check `llms.txt` for the list of approved LLMs.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Before running `f2clipboard`, install the required Python packages:
 pip install clipboard
 ```
 
+If developing locally, install the package in editable mode:
+
+```bash
+pip install -e .
+```
+
 ## Requirements
 
 - Python 3.x
@@ -50,6 +56,21 @@ To use `f2clipboard`, follow these steps:
    ```plaintext
    🔍 Enter file numbers to add, 'list' to review, or 'done' to finalize: done
    ```
+
+### Command Line Flags
+
+`f2clipboard` also supports non-interactive use. The following example selects
+all Python files under `src/` and copies them directly to your clipboard:
+
+```bash
+f2clipboard -d src -p '*.py' --yes
+```
+
+### Example: MCP Agent Workflow
+
+1. Run the command above to gather the files you want to discuss.
+2. Paste the output into your MCP agent (e.g., in a chat window).
+3. Ask the agent to analyze or transform the selected files.
 
 ## Known Limitations
 

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -1,6 +1,7 @@
-import shutil
-import os
+import argparse
 import fnmatch
+import os
+import shutil
 import clipboard
 
 # Add common image and binary file extensions to exclude
@@ -223,14 +224,48 @@ def format_files_for_clipboard(files, directory, ignore_patterns):
     return result
 
 
-def main():
-    directory = input("📁 Enter the directory path to search files: ")
-    pattern = input(
+def parse_args(args=None):
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Collect files and copy formatted Markdown to the clipboard"
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        help="Directory path to search. Defaults to interactive prompt",
+    )
+    parser.add_argument(
+        "-p",
+        "--pattern",
+        default="*",
+        help="File pattern to search, e.g. '*.txt' or '*.{py,js}'",
+    )
+    parser.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        help="Select all matching files without prompting",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s 0.1.0",
+    )
+    return parser.parse_args(args)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    directory = args.directory or input("📁 Enter the directory path to search files: ")
+    pattern = args.pattern or input(
         "🔎 Enter the file pattern to search (examples: '*.txt', '*.{py,js}', 'test_*.py', '*config*'): "
     )
     ignore_patterns = parse_gitignore()
     files = list_files(directory, pattern, ignore_patterns)
-    selected_files = select_files(files)
+    if args.yes:
+        selected_files = list(files)
+    else:
+        selected_files = select_files(files)
 
     if selected_files:
         clipboard_content = format_files_for_clipboard(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "f2clipboard"
+version = "0.1.0"
+description = "CLI utility to copy formatted files to the clipboard"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = ["clipboard"]
+
+[project.scripts]
+f2clipboard = "f2clipboard:main"
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,33 @@
 import os
 import sys
+import tempfile
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+@pytest.fixture
+def temp_directory():
+    """Create a temporary directory with test files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "src"))
+        os.makedirs(os.path.join(tmpdir, "assets"))
+
+        with open(os.path.join(tmpdir, "file1.txt"), "w") as f:
+            f.write("test content 1")
+        with open(os.path.join(tmpdir, "src/file2.py"), "w") as f:
+            f.write("test content 2")
+        with open(os.path.join(tmpdir, "src/app.js"), "w") as f:
+            f.write("test content 3")
+        with open(os.path.join(tmpdir, "src/styles.css"), "w") as f:
+            f.write("test content 4")
+
+        with open(os.path.join(tmpdir, "assets/test.jpg"), "wb") as f:
+            f.write(b"fake jpg content")
+        with open(os.path.join(tmpdir, "assets/icon.png"), "wb") as f:
+            f.write(b"fake png content")
+
+        with open(os.path.join(tmpdir, ".gitignore"), "w") as f:
+            f.write("*.log\nnode_modules/\n")
+
+        yield tmpdir

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,0 +1,12 @@
+from unittest.mock import patch
+
+import sys
+
+
+def test_cli_yes(temp_directory):
+    argv = ["-d", temp_directory, "-p", "*.txt", "--yes"]
+    with patch("clipboard.copy") as mock_copy:
+        from f2clipboard import main
+
+        main(argv)
+        assert mock_copy.called

--- a/tests/test_f2clipboard.py
+++ b/tests/test_f2clipboard.py
@@ -1,7 +1,5 @@
 import pytest
 import os
-import tempfile
-import shutil
 from unittest.mock import patch, MagicMock
 from f2clipboard import (
     parse_gitignore,
@@ -10,37 +8,6 @@ from f2clipboard import (
     format_files_for_clipboard,
     EXCLUDED_EXTENSIONS,
 )
-
-
-@pytest.fixture
-def temp_directory():
-    """Create a temporary directory with test files."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # Create some test files
-        os.makedirs(os.path.join(tmpdir, "src"))
-        os.makedirs(os.path.join(tmpdir, "assets"))
-
-        # Create text files
-        with open(os.path.join(tmpdir, "file1.txt"), "w") as f:
-            f.write("test content 1")
-        with open(os.path.join(tmpdir, "src/file2.py"), "w") as f:
-            f.write("test content 2")
-        with open(os.path.join(tmpdir, "src/app.js"), "w") as f:
-            f.write("test content 3")
-        with open(os.path.join(tmpdir, "src/styles.css"), "w") as f:
-            f.write("test content 4")
-
-        # Create binary/image files
-        with open(os.path.join(tmpdir, "assets/test.jpg"), "wb") as f:
-            f.write(b"fake jpg content")
-        with open(os.path.join(tmpdir, "assets/icon.png"), "wb") as f:
-            f.write(b"fake png content")
-
-        # Create .gitignore
-        with open(os.path.join(tmpdir, ".gitignore"), "w") as f:
-            f.write("*.log\nnode_modules/\n")
-
-        yield tmpdir
 
 
 def test_parse_gitignore(temp_directory):
@@ -164,7 +131,7 @@ def test_main_workflow(mock_clipboard, mock_input, temp_directory):
 
     # Run main function
     with patch("sys.stdout"):  # Suppress print statements
-        main()
+        main([])
 
     # Verify clipboard was called
     assert mock_clipboard.called
@@ -190,7 +157,7 @@ def test_main_workflow_multi_pattern(mock_clipboard, mock_input, temp_directory)
 
     # Run main function
     with patch("sys.stdout"):  # Suppress print statements
-        main()
+        main([])
 
     # Verify clipboard was called and contains both types of files
     assert mock_clipboard.called


### PR DESCRIPTION
## Summary
- expose `f2clipboard` flags via argparse
- add packaging via `pyproject.toml`
- show new CLI workflow in README and AGENTS guide
- factor out shared test fixture and add CLI test
- include Flywheel GitHub Actions

## Testing
- `black -q f2clipboard.py tests/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686245de87f4832fad86751fbd75b370