### PR TITLE
Add uv usage explanation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,4 +16,5 @@ repos:
           - black
           - isort
           - pytest
+          - clipboard
         pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This project uses lightweight command line utilities to copy files into Markdown
 ## Setup
 1. Ensure Python 3.x is installed.
 2. Install dependencies with `uv pip install --system clipboard` and `uv pip install --system -e .`.
+   These commands use **uv** instead of `pip`. If uv isn't installed, run `pipx install uv` or `pip install uv` first.
 3. Optionally create a virtual environment for isolation.
 4. Check `llms.txt` for the list of approved LLMs.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,12 @@ This repository is intentionally minimal, but it reuses ideas from the [flywheel
 
 ## Installation
 
-Before running `f2clipboard`, install the package and its dependency:
+Before running `f2clipboard`, install the package and its dependency. The
+commands below use **uv**, a fast Python package installer that acts as a
+drop-in replacement for `pip`. If you don't have it yet, you can install
+uv via `pipx install uv` (or `pip install uv`). The `--system` flag tells uv to
+install packages into your current Python environment instead of creating a
+virtual environment.
 
 ```bash
 uv pip install --system clipboard


### PR DESCRIPTION
## Summary
- clarify how `uv` works for installing packages in README
- note about installing `uv` in AGENTS docs
- include clipboard in pre-commit test deps for hooks

## Testing
- `pre-commit run --files README.md AGENTS.md .pre-commit-config.yaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc26c4bec832fa1bbae307d6cabad