### PR TITLE
feat: parse Codex task PR URLs and add prompt guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ f2clipboard files --dir path/to/project
 
 ## Roadmap
 ### M0 (bootstrap)
-- [ ] Ship basic CLI with `codex-task` command and help text.
-- [ ] Support GitHub personal-access tokens via `.env`.
-- [ ] Fetch PR URL from Codex task HTML (unauthenticated test page).
+- [x] Ship basic CLI with `codex-task` command and help text.
+- [x] Support GitHub personal-access tokens via `.env`.
+- [x] Fetch PR URL from Codex task HTML (unauthenticated test page).
 
 ### M1 (minimum lovable product)
 - [ ] Parse check-suites with GitHub REST v3.
@@ -82,4 +82,4 @@ f2clipboard files --dir path/to/project
 
 ## Contributing
 
-See [AGENTS.md](AGENTS.md) for LLM-specific guidelines and [CONTRIBUTING.md](CONTRIBUTING.md) for the standard contribution workflow.
+See [AGENTS.md](AGENTS.md) for LLM-specific guidelines and [CONTRIBUTING.md](CONTRIBUTING.md) for the standard contribution workflow. Prompt templates live in [docs/prompts-codex.md](docs/prompts-codex.md).

--- a/docs/prompts-codex.md
+++ b/docs/prompts-codex.md
@@ -1,0 +1,51 @@
+---
+title: 'Codex Prompts'
+slug: 'prompts-codex'
+---
+
+# Codex prompts for the *f2clipboard* repo
+
+Codex can automate improvements to this repository when given clear, scoped instructions.
+Use the templates below to craft prompts and track roadmap progress.
+
+## Reusable template
+
+```text
+You are working in futuroptimist/f2clipboard.
+
+GOAL: <one sentence>.
+
+FILES OF INTEREST
+- <path/to/File1>   ← brief hint
+- <path/to/File2>
+
+REQUIREMENTS
+1. …
+2. …
+3. …
+
+OUTPUT
+Return **only** the patch (diff) needed.
+```
+
+## Implementation Prompt
+
+Tasks are tracked in [README.md](../README.md) under "Roadmap" using Markdown checkboxes.
+Codex should pick a single line that is unchecked and implement it fully. After
+all checks pass, mark the corresponding line with `💯`.
+
+```text
+SYSTEM:
+You are an automated contributor for the f2clipboard repository. Choose one
+item from README.md's "Roadmap" section that is `[ ]` or `[x]` without `💯`.
+Implement it completely with code, tests and documentation. Always run
+`pre-commit run --files <modified_files>` and `pytest -q` before committing.
+
+USER:
+1. Follow the steps above.
+2. After verifying the implementation, mark the README line with `💯`.
+3. Document new functionality as needed.
+
+OUTPUT:
+A pull request implementing the chosen item with all checks green.
+```

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -3,18 +3,40 @@
 from __future__ import annotations
 
 import asyncio
+import re
 
+import httpx
 import typer
+
+from .config import Settings
+
+
+async def _fetch_task_html(url: str) -> str:
+    """Fetch raw HTML for a Codex task page."""
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.text
+
+
+def _extract_pr_url(html: str) -> str | None:
+    """Return the first GitHub PR URL found in the given HTML."""
+    match = re.search(r'href="(https://github.com/[^"]+/pull/\d+)"', html)
+    return match.group(1) if match else None
 
 
 async def _process_task(url: str) -> str:
-    """Placeholder async workflow for processing a Codex task."""
-    await asyncio.sleep(0)  # TODO: implement real logic
-    return f"processed {url}"
+    """Download the task page and extract the linked PR URL."""
+    html = await _fetch_task_html(url)
+    pr_url = _extract_pr_url(html)
+    return pr_url or "PR URL not found"
 
 
-def codex_task_command(url: str) -> None:
-    """Entry point used by the Typer CLI."""
+def codex_task_command(
+    url: str = typer.Argument(..., help="Codex task URL to process"),
+) -> None:
+    """Parse a Codex task page and print its GitHub PR URL."""
     typer.echo(f"Parsing Codex task page: {url}…")
+    Settings()  # load environment (e.g. GITHUB_TOKEN) for future use
     result = asyncio.run(_process_task(url))
     typer.echo(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "typer>=0.9.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
+    "httpx",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -1,0 +1,10 @@
+from f2clipboard.codex_task import _extract_pr_url
+
+
+def test_extract_pr_url_success():
+    html = '<html><a href="https://github.com/owner/repo/pull/123">PR</a></html>'
+    assert _extract_pr_url(html) == "https://github.com/owner/repo/pull/123"
+
+
+def test_extract_pr_url_missing():
+    assert _extract_pr_url("<html></html>") is None


### PR DESCRIPTION
## Summary
- fetch Codex task HTML and surface linked PR URL
- document prompt templates for Codex contributions
- mark initial roadmap tasks as complete

## Testing
- `pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py README.md docs/prompts-codex.md pyproject.toml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ef242025c832f8ac3180c24ebb4df