### PR TITLE
feat: copy codex output to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ f2clipboard files --dir path/to/project
 - [x] Parse check-suites with GitHub REST v3.
 - [x] Download raw logs; gzip-decode when necessary.
 - [ ] Size-gate logs → summarise via LLM.
-- [ ] Write Markdown artefact to `stdout` **and** clipboard.
+- [x] Write Markdown artefact to `stdout` **and** clipboard. 💯
 
 ### M2 (hardening)
 - [ ] Playwright headless login for private Codex tasks.
@@ -73,6 +73,8 @@ Generate a Markdown snippet for a Codex task:
 ```bash
 f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123
 ```
+
+The Markdown report prints to your terminal and is copied to your clipboard for easy pasting.
 
 Copy selected files from a local repository:
 

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -8,6 +8,7 @@ import re
 from typing import Any
 
 import httpx
+import pyperclip
 import typer
 
 from .config import Settings
@@ -106,3 +107,7 @@ def codex_task_command(
     settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
     result = asyncio.run(_process_task(url, settings))
     typer.echo(result)
+    try:
+        pyperclip.copy(result)
+    except pyperclip.PyperclipException:
+        typer.secho("Warning: could not copy to clipboard", err=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 requires-python = ">=3.8"
 dependencies = [
     "clipboard",
+    "pyperclip",
     "typer>=0.9.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -1,5 +1,9 @@
 import gzip
 
+import pyperclip
+from typer.testing import CliRunner
+
+from f2clipboard import app, codex_task
 from f2clipboard.codex_task import _decode_log, _extract_pr_url, _parse_pr_url
 
 
@@ -27,3 +31,40 @@ def test_decode_log_handles_gzip():
 
 def test_decode_log_plain():
     assert _decode_log(b"plain") == "plain"
+
+
+def test_codex_task_copies_to_clipboard(monkeypatch):
+    runner = CliRunner()
+
+    async def fake_process(url: str, settings: object) -> str:
+        return "report"
+
+    monkeypatch.setattr(codex_task, "_process_task", fake_process)
+    captured: dict[str, str] = {}
+
+    def fake_copy(text: str) -> None:
+        captured["text"] = text
+
+    monkeypatch.setattr(pyperclip, "copy", fake_copy)
+    result = runner.invoke(app, ["codex-task", "https://example.com/task"])
+    assert result.exit_code == 0
+    assert "report" in result.stdout
+    assert captured["text"] == "report"
+
+
+def test_codex_task_warns_without_clipboard(monkeypatch):
+    runner = CliRunner()
+
+    async def fake_process(url: str, settings: object) -> str:
+        return "report"
+
+    monkeypatch.setattr(codex_task, "_process_task", fake_process)
+
+    def fake_copy(text: str) -> None:
+        raise pyperclip.PyperclipException("no clipboard")
+
+    monkeypatch.setattr(pyperclip, "copy", fake_copy)
+    result = runner.invoke(app, ["codex-task", "https://example.com/task"])
+    assert result.exit_code == 0
+    assert "report" in result.stdout
+    assert "clipboard" in result.stderr.lower()


### PR DESCRIPTION
## Summary
- copy `codex-task` Markdown output to user's clipboard via pyperclip
- cover clipboard success and failure with new tests
- document clipboard behavior and mark roadmap item complete

## Testing
- `pre-commit run --files pyproject.toml f2clipboard/codex_task.py tests/test_codex_task.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68904cadaa30832f9efa7790af690071