### PR TITLE
Add clipboard copy to codex task output

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ f2clipboard files --dir path/to/project
 - [x] Parse check-suites with GitHub REST v3.
 - [x] Download raw logs; gzip-decode when necessary.
 - [x] Size-gate logs → summarise via LLM. 💯
-- [ ] Write Markdown artefact to `stdout` **and** clipboard.
+- [x] Write Markdown artefact to `stdout` **and** clipboard. 💯
 
 ### M2 (hardening)
 - [ ] Playwright headless login for private Codex tasks.
@@ -74,6 +74,8 @@ Generate a Markdown snippet for a Codex task:
 ```bash
 f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123
 ```
+
+The resulting Markdown is printed to your terminal and copied to the clipboard.
 
 Copy selected files from a local repository:
 

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -7,6 +7,7 @@ import gzip
 import re
 from typing import Any
 
+import clipboard
 import httpx
 import typer
 
@@ -111,4 +112,5 @@ def codex_task_command(
     typer.echo(f"Parsing Codex task page: {url}…")
     settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
     result = asyncio.run(_process_task(url, settings))
+    clipboard.copy(result)
     typer.echo(result)

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -6,6 +6,7 @@ from f2clipboard.codex_task import (
     _extract_pr_url,
     _parse_pr_url,
     _process_task,
+    codex_task_command,
 )
 from f2clipboard.config import Settings
 
@@ -87,3 +88,20 @@ def test_process_task_small_log_skips_summarise(monkeypatch):
     result = asyncio.run(_process_task("http://task", settings))
     assert "short" in result
     assert not called
+
+
+def test_codex_task_command_copies_to_clipboard(monkeypatch, capsys):
+    async def fake_process(url: str, settings: Settings) -> str:
+        return "MD"
+
+    monkeypatch.setattr("f2clipboard.codex_task._process_task", fake_process)
+    copied: dict[str, str] = {}
+
+    def fake_copy(text: str) -> None:
+        copied["text"] = text
+
+    monkeypatch.setattr("f2clipboard.codex_task.clipboard.copy", fake_copy)
+    codex_task_command("http://task")
+    out = capsys.readouterr().out
+    assert "MD" in out
+    assert copied["text"] == "MD"


### PR DESCRIPTION
## Summary
- copy Codex task Markdown output to the system clipboard
- document clipboard behavior and mark roadmap item complete
- test that Codex task command writes output to clipboard

## Testing
- `pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68905c599290832fafd576eef662c2ad