### PR TITLE
feat: redact sensitive tokens from logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ For every successful check → ignore.
 
 If a log exceeds 150 kB → invoke an LLM (configurable, OpenAI or Anthropic) to summarise the failure.
 
+Secrets such as API tokens are redacted from logs before summarisation or output.
+
 Emit a Markdown snippet ready for pasting back into Codex:
 
 Each failed check becomes a fenced code-block labelled with job name & link.
@@ -51,7 +53,7 @@ f2clipboard files --dir path/to/project
 
 ### M2 (hardening)
 - [ ] Playwright headless login for private Codex tasks.
-- [ ] Secret scanning & redaction (via `talisman` or custom regex).
+- [x] Secret scanning & redaction (via custom regex). 💯
 - [ ] Unit tests (pytest + `pytest-recording` vcr).
 
 ### M3 (extensibility)

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -13,6 +13,7 @@ import typer
 
 from .config import Settings
 from .llm import summarise_log
+from .secret import redact_secrets
 
 GITHUB_API = "https://api.github.com"
 
@@ -93,6 +94,7 @@ async def _process_task(url: str, settings: Settings) -> str:
             if run.get("conclusion") == "success":
                 continue
             log_text = await _download_log(client, owner, repo, run["id"])
+            log_text = redact_secrets(log_text)
             if len(log_text.encode()) > settings.log_size_threshold:
                 summary = await summarise_log(log_text, settings)
                 snippet = "\n".join(log_text.splitlines()[:100])

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from f2clipboard.codex_task import _process_task
+from f2clipboard.config import Settings
+from f2clipboard.secret import redact_secrets
+
+
+def test_redact_secrets():
+    token = "ghp_" + "a" * 36
+    text = f"TOKEN=abcdef123456 {token}"
+    redacted = redact_secrets(text)
+    assert "abcdef123456" not in redacted
+    assert "ghp_REDACTED" in redacted
+    assert "TOKEN=***" in redacted
+
+
+def test_process_task_redacts(monkeypatch):
+    async def fake_html(url: str) -> str:
+        return '<a href="https://github.com/o/r/pull/1">PR</a>'
+
+    async def fake_runs(pr_url: str, token: str | None):
+        return [{"id": 1, "name": "Job", "conclusion": "failure"}]
+
+    async def fake_log(client, owner, repo, run_id):
+        return "TOKEN=abcdef123456"
+
+    async def fake_summary(text: str, settings: Settings) -> str:
+        assert "abcdef123456" not in text
+        return "SUMMARY"
+
+    monkeypatch.setattr("f2clipboard.codex_task._fetch_task_html", fake_html)
+    monkeypatch.setattr("f2clipboard.codex_task._fetch_check_runs", fake_runs)
+    monkeypatch.setattr("f2clipboard.codex_task._download_log", fake_log)
+    monkeypatch.setattr("f2clipboard.codex_task.summarise_log", fake_summary)
+
+    settings = Settings()
+    settings.log_size_threshold = 0
+    result = asyncio.run(_process_task("http://task", settings))
+    assert "abcdef123456" not in result
+    assert "SUMMARY" in result


### PR DESCRIPTION
## Summary
- redact secrets like API tokens from logs using regex patterns
- run redaction during Codex task processing so summaries omit secrets
- document secret redaction and mark roadmap item complete

## Testing
- `pre-commit run --files f2clipboard/secret.py f2clipboard/codex_task.py README.md tests/test_secret.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68905e8e58dc832fb808040b1d4ce056