### PR TITLE
Add pytest-recording unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ f2clipboard files --dir path/to/project
 ### M2 (hardening)
 - [ ] Playwright headless login for private Codex tasks.
 - [ ] Secret scanning & redaction (via `talisman` or custom regex).
-- [ ] Unit tests (pytest + `pytest-recording` vcr).
+- [x] Unit tests (pytest + `pytest-recording` vcr). 💯
 
 ### M3 (extensibility)
 - [ ] Plugin interface (`entry_points = "f2clipboard.plugins"`).

--- a/tests/cassettes/test_codex_task/test_fetch_task_html_records_example.yaml
+++ b/tests/cassettes/test_codex_task/test_fetch_task_html_records_example.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - example.com
+      user-agent:
+      - python-httpx/0.28.1
+    method: GET
+    uri: https://example.com
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAH1UTXPbIBC9+1ds1UsyIyQnaRqPLWn6mWkPaQ9pDz0SsbKYCFAByfZ08t+7Qo4j
+        N5makYFdeLvvsZC9Eqb0uxah9qopZtljh1wUM6Bf5qVvsPi85aptED4ZxaXO0tE6G5co9BzKmluH
+        Po86X7FFBGkxcdbetwx/d7LPo49Ge9SeDWEjKMdZHnnc+nQIvzpAvYSkucI86iVuWmP9ZP9GCl/n
+        AntZIguTGKSWXvKGuZI3mJ89QTm/IzJDBvvApXPR6LszYgd/wjBMeXm/tqbTgpWmMXYJr6s5tfPV
+        YYnidi31EuZPppYLIfX6yFZRpqziSja7JTDekpzM7ZxHFcPYs07G8KGR+v6Gl7fBdE2bYohucW0Q
+        fn6NaPy9RQ23XLth8gWbHr0sOXzDDslyMMTw3hJ3wqalzKGV1VMuYfAQ/oXsJ3SDcEt4O5+32+cM
+        L1EB77x5geg5qtV/RRPUJhncGSvQMsuF7BzplFweAZgtczUXZkPI7RYu6Luibxjb9R0/mcehJfPz
+        09WEDF8O6sXU99JJj2JC7TGTi8WbxWKSyXD+TGBpLPfSEEttNE5B3ykUksOJ4lu21+dq0Od0An6s
+        4lFV/KPYROVjx8MkZJaGCi3CWWXpeB1n2VCbdDsp2L6O67NnN5NMo68tftTSgQh2oFFlLHQOYZg1
+        Tef8QLhHwBHBDQ56DjpF98kl8Mt0RGIXtnhCGqtlj6ahIXkJoLNIdHxtOg+tlRSiNHS0Ugcxgebc
+        3VOFhOgtWiWdI0eSpe0hz4weCItVHg3PhFum6WazSSTXPDF2nY4hXbpPMypujB1IEKAKQZKE0HgR
+        ELM0iJOle6nS8UH7CyjrfG/oBAAA
+    headers:
+      accept-ranges:
+      - bytes
+      alt-svc:
+      - h3=":443"; ma=93600,h3-29=":443"; ma=93600
+      cache-control:
+      - max-age=2175
+      content-encoding:
+      - gzip
+      content-length:
+      - '648'
+      content-type:
+      - text/html
+      date:
+      - Mon, 04 Aug 2025 07:20:06 GMT
+      etag:
+      - '"84238dfc8092e5d9c0dac8ef93371a07:1736799080.121134"'
+      last-modified:
+      - Mon, 13 Jan 2025 20:11:20 GMT
+      server:
+      - envoy
+      vary:
+      - Accept-Encoding
+      x-envoy-upstream-service-time:
+      - '153'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -1,9 +1,12 @@
 import asyncio
 import gzip
 
+import pytest
+
 from f2clipboard.codex_task import (
     _decode_log,
     _extract_pr_url,
+    _fetch_task_html,
     _parse_pr_url,
     _process_task,
     codex_task_command,
@@ -105,3 +108,9 @@ def test_codex_task_command_copies_to_clipboard(monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "MD" in out
     assert copied["text"] == "MD"
+
+
+@pytest.mark.vcr()
+def test_fetch_task_html_records_example():
+    html = asyncio.run(_fetch_task_html("https://example.com"))
+    assert "Example Domain" in html


### PR DESCRIPTION
## Summary
- add VCR-backed test for `_fetch_task_html` and record example.com response
- mark roadmap unit tests item as complete

## Testing
- `pre-commit run --files README.md tests/test_codex_task.py tests/cassettes/test_codex_task/test_fetch_task_html_records_example.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68905e8e58dc832fb808040b1d4ce056