### PR TITLE
feat: redact secrets from codex logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Query the GitHub API for the check-suite:
 
 For every failed check → download full raw logs.
 
+Scan logs for known secrets and redact them.
+
 For every successful check → ignore.
 
 If a log exceeds 150 kB → invoke an LLM (configurable, OpenAI or Anthropic) to summarise the failure.
@@ -51,7 +53,7 @@ f2clipboard files --dir path/to/project
 
 ### M2 (hardening)
 - [ ] Playwright headless login for private Codex tasks.
-- [ ] Secret scanning & redaction (via `talisman` or custom regex).
+- [x] Secret scanning & redaction (via `talisman` or custom regex). 💯
 - [ ] Unit tests (pytest + `pytest-recording` vcr).
 
 ### M3 (extensibility)

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -13,6 +13,7 @@ import typer
 
 from .config import Settings
 from .llm import summarise_log
+from .redaction import redact_secrets
 
 GITHUB_API = "https://api.github.com"
 
@@ -93,6 +94,7 @@ async def _process_task(url: str, settings: Settings) -> str:
             if run.get("conclusion") == "success":
                 continue
             log_text = await _download_log(client, owner, repo, run["id"])
+            log_text = redact_secrets(log_text)
             if len(log_text.encode()) > settings.log_size_threshold:
                 summary = await summarise_log(log_text, settings)
                 snippet = "\n".join(log_text.splitlines()[:100])

--- a/f2clipboard/redaction.py
+++ b/f2clipboard/redaction.py
@@ -1,0 +1,25 @@
+"""Utilities for scanning and redacting secrets from text."""
+
+from __future__ import annotations
+
+import re
+
+# Regular expressions for common secret formats
+_PATTERNS: list[re.Pattern[str]] = [
+    # GitHub personal access tokens, e.g. ghp_xxx...
+    re.compile(r"gh[pousr]_[A-Za-z0-9]{36}"),
+    # AWS access key IDs
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+]
+
+
+def redact_secrets(text: str) -> str:
+    """Replace known secret patterns with ``[REDACTED]``.
+
+    The function performs simple pattern matching to remove credentials from
+    logs before they are printed or sent to an LLM.
+    """
+
+    for pattern in _PATTERNS:
+        text = pattern.sub("[REDACTED]", text)
+    return text

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,13 @@
+from f2clipboard.redaction import redact_secrets
+
+
+def test_redact_github_token():
+    token = "ghp_1234567890abcdef1234567890abcdef1234"
+    text = f"token={token}"
+    assert redact_secrets(text) == "token=[REDACTED]"
+
+
+def test_redact_aws_access_key():
+    key = "AKIA1234567890ABCDEF"
+    text = f"key {key}"
+    assert redact_secrets(text) == "key [REDACTED]"


### PR DESCRIPTION
## Summary
- redact known tokens like GitHub and AWS keys before processing logs
- test redaction utility and integration with Codex task workflow
- document automatic secret redaction and mark roadmap item complete

## Testing
- `pre-commit run --files f2clipboard/redaction.py f2clipboard/codex_task.py README.md tests/test_redaction.py tests/test_codex_task.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68905e8e58dc832fb808040b1d4ce056