### PR TITLE
✨ add plugin interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ f2clipboard files --dir path/to/project
 - [x] Secret scanning & redaction (via custom regex). 💯
 
 ### M3 (extensibility)
-- [ ] Plugin interface (`entry_points = "f2clipboard.plugins"`).
+- [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯
 - [ ] First plugin: Jira ticket summariser.
 - [ ] VS Code task provider / GitHub Action marketplace listing.
 
@@ -83,6 +83,16 @@ Copy selected files from a local repository:
 
 ```bash
 f2clipboard files --dir path/to/project
+```
+
+## Plugins
+
+f2clipboard loads plugins registered under the `f2clipboard.plugins` entry-point group. A plugin
+exposes a callable that receives the Typer app and can register additional commands.
+
+```toml
+[project.entry-points."f2clipboard.plugins"]
+hello = "my_package.plugin:register"
 ```
 
 ## Contributing

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,32 @@
+"""Tests for plugin interface."""
+
+import importlib
+from importlib.metadata import EntryPoint
+
+import f2clipboard
+
+
+def plugin(app):
+    """Sample plugin to register a command."""
+
+    @app.command("hello")
+    def hello_cmd() -> None:  # pragma: no cover - invoked via Typer
+        """Dummy plugin command."""
+        pass
+
+
+def test_plugin_loaded(monkeypatch):
+    ep = EntryPoint(
+        name="sample", value="tests.test_plugins:plugin", group="f2clipboard.plugins"
+    )
+
+    def fake_entry_points(*args, **kwargs):
+        if kwargs.get("group") == "f2clipboard.plugins":
+            return [ep]
+        return []
+
+    importlib.reload(f2clipboard)
+    monkeypatch.setattr(f2clipboard, "entry_points", fake_entry_points)
+    f2clipboard._load_plugins()
+    names = [cmd.name for cmd in f2clipboard.app.registered_commands]
+    assert "hello" in names


### PR DESCRIPTION
## Summary
- load plugins via `f2clipboard.plugins` entry points
- document plugin usage and mark roadmap item complete
- test plugin registration

## Testing
- `pre-commit run --files README.md f2clipboard/__init__.py tests/test_plugins.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892decd1ec8832f853bf01cbaa4bde6