### PR TITLE
🧪 : test GitHub check-run parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ f2clipboard files --dir path/to/project
 - [x] Fetch PR URL from Codex task HTML (unauthenticated test page).
 
 ### M1 (minimum lovable product)
-- [x] Parse check-suites with GitHub REST v3.
+- [x] Parse check-suites with GitHub REST v3. 💯
 - [x] Download raw logs; gzip-decode when necessary.
 - [x] Size-gate logs → summarise via LLM. 💯
 - [x] Write Markdown artefact to `stdout` **and** clipboard. 💯


### PR DESCRIPTION
## Summary
- test that GitHub check runs are parsed via REST v3
- mark roadmap entry complete with 💯

## Testing
- `pre-commit run --files README.md tests/test_codex_task.py`
- `pytest -q`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6892decd1ec8832f853bf01cbaa4bde6