### PR TITLE
✨ : add --no-clipboard flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123
 ```
 
 The resulting Markdown is printed to your terminal and copied to the clipboard.
+To skip copying to the clipboard, pass ``--no-clipboard``:
+
+```bash
+f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --no-clipboard
+```
 
 Copy selected files from a local repository:
 

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -109,10 +109,19 @@ async def _process_task(url: str, settings: Settings) -> str:
 
 def codex_task_command(
     url: str = typer.Argument(..., help="Codex task URL to process"),
+    copy_to_clipboard: bool = typer.Option(
+        True,
+        "--clipboard/--no-clipboard",
+        help="Copy result to the system clipboard.",
+    ),
 ) -> None:
-    """Parse a Codex task page and print any failing GitHub checks."""
+    """Parse a Codex task page and print any failing GitHub checks.
+
+    The generated Markdown is copied to the clipboard unless ``--no-clipboard`` is passed.
+    """
     typer.echo(f"Parsing Codex task page: {url}…")
     settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
     result = asyncio.run(_process_task(url, settings))
-    clipboard.copy(result)
+    if copy_to_clipboard:
+        clipboard.copy(result)
     typer.echo(result)

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -145,6 +145,23 @@ def test_codex_task_command_copies_to_clipboard(monkeypatch, capsys):
     assert copied["text"] == "MD"
 
 
+def test_codex_task_command_skips_clipboard(monkeypatch, capsys):
+    async def fake_process(url: str, settings: Settings) -> str:
+        return "MD"
+
+    monkeypatch.setattr("f2clipboard.codex_task._process_task", fake_process)
+    copied: dict[str, str] = {}
+
+    def fake_copy(text: str) -> None:
+        copied["text"] = text
+
+    monkeypatch.setattr("f2clipboard.codex_task.clipboard.copy", fake_copy)
+    codex_task_command("http://task", copy_to_clipboard=False)
+    out = capsys.readouterr().out
+    assert "MD" in out
+    assert not copied
+
+
 @pytest.mark.vcr()
 def test_fetch_task_html_records_example():
     html = asyncio.run(_fetch_task_html("https://example.com"))


### PR DESCRIPTION
what: codex-task command now accepts --no-clipboard to skip copying
why: allow running without touching system clipboard
how to test: pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py README.md && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6893c0f8c648832f90a6cc0557bf1355