### PR TITLE
feat: robust gzip log decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ f2clipboard files --dir path/to/project
 
 ### M1 (minimum lovable product)
 - [x] Parse check-suites with GitHub REST v3. 💯
-- [x] Download raw logs; gzip-decode when necessary.
+- [x] Download raw logs; gzip-decode when necessary. 💯
 - [x] Size-gate logs → summarise via LLM. 💯
 - [x] Write Markdown artefact to `stdout` **and** clipboard. 💯
 


### PR DESCRIPTION
## Summary
- improve gzip detection for GitHub logs
- add tests for gzipped log downloads
- mark roadmap item complete

## Testing
- `pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c10be288832f8c86fe42a158dd82