### PR TITLE
✨ : add Jira ticket summariser plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ f2clipboard files --dir path/to/project
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯
-- [ ] First plugin: Jira ticket summariser.
+- [x] First plugin: Jira ticket summariser. 💯
 - [ ] VS Code task provider / GitHub Action marketplace listing.
 
 ## Getting Started
@@ -94,6 +94,15 @@ exposes a callable that receives the Typer app and can register additional comma
 [project.entry-points."f2clipboard.plugins"]
 hello = "my_package.plugin:register"
 ```
+
+The first bundled plugin summarises Jira issues:
+
+```bash
+f2clipboard jira path/to/issue.json
+```
+
+Provide either a Jira issue URL or a path to a JSON export. The ticket's description is summarised
+and copied to your clipboard.
 
 ## Contributing
 

--- a/f2clipboard/plugins/jira.py
+++ b/f2clipboard/plugins/jira.py
@@ -1,0 +1,50 @@
+"""Jira ticket summariser plugin."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import clipboard
+import httpx
+import typer
+
+from ..config import Settings
+from ..llm import summarise_log
+
+
+async def _load_issue(source: str) -> dict[str, Any]:
+    """Return Jira issue JSON from a local file or HTTP URL."""
+    path = Path(source)
+    if path.exists():
+        return json.loads(path.read_text())
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(source, headers={"Accept": "application/json"})
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def _summarise_issue(source: str, settings: Settings) -> str:
+    """Fetch, summarise and return Jira issue text."""
+    issue = await _load_issue(source)
+    fields = issue.get("fields", {})
+    summary = fields.get("summary") or ""
+    description = fields.get("description") or ""
+    text = f"{summary}\n\n{description}"
+    return await summarise_log(text, settings)
+
+
+def register(app: typer.Typer) -> None:
+    """Register the Jira command with the main Typer application."""
+
+    @app.command()
+    def jira(
+        source: str = typer.Argument(..., help="Jira issue URL or path to JSON file"),
+    ) -> None:
+        """Summarise a Jira ticket and copy result to the clipboard."""
+        settings = Settings()
+        result = asyncio.run(_summarise_issue(source, settings))
+        clipboard.copy(result)
+        typer.echo(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ dev = [
 [project.scripts]
 f2clipboard = "f2clipboard.cli:main"
 
+[project.entry-points."f2clipboard.plugins"]
+jira = "f2clipboard.plugins.jira:register"
+
 [tool.pytest.ini_options]
 addopts = "-q"
 

--- a/tests/test_jira_plugin.py
+++ b/tests/test_jira_plugin.py
@@ -1,0 +1,24 @@
+import json
+
+from typer.testing import CliRunner
+
+from f2clipboard import app
+from f2clipboard.plugins.jira import register
+
+
+def test_jira_plugin_from_file(tmp_path, monkeypatch):
+    register(app)
+    issue = {
+        "fields": {
+            "summary": "Test issue",
+            "description": "Detailed description of issue",
+        }
+    }
+    path = tmp_path / "issue.json"
+    path.write_text(json.dumps(issue))
+    monkeypatch.setattr("f2clipboard.plugins.jira.clipboard.copy", lambda _: None)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["jira", str(path)])
+    assert result.exit_code == 0
+    assert "Test issue" in result.stdout


### PR DESCRIPTION
## Summary
- add Jira ticket summariser plugin
- document plugin and mark roadmap item

## Testing
- `pre-commit run --files pyproject.toml README.md f2clipboard/plugins/jira.py tests/test_jira_plugin.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c10be288832f8c86fe42a158dd82