### PR TITLE
✨ : add --no-copy flag to codex-task

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123
 ```
 
 The resulting Markdown is printed to your terminal and copied to the clipboard.
+Pass `--no-copy` to skip copying to the clipboard.
 
 Copy selected files from a local repository:
 

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -109,10 +109,16 @@ async def _process_task(url: str, settings: Settings) -> str:
 
 def codex_task_command(
     url: str = typer.Argument(..., help="Codex task URL to process"),
+    copy_to_clipboard: bool = typer.Option(
+        True,
+        "--copy/--no-copy",
+        help="Copy result to clipboard",
+    ),
 ) -> None:
     """Parse a Codex task page and print any failing GitHub checks."""
     typer.echo(f"Parsing Codex task page: {url}…")
     settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
     result = asyncio.run(_process_task(url, settings))
-    clipboard.copy(result)
+    if copy_to_clipboard:
+        clipboard.copy(result)
     typer.echo(result)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -26,6 +26,22 @@ def test_cli_help():
     assert "files" in result.stdout
 
 
+def test_codex_task_help_shows_no_copy():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "f2clipboard.cli",
+            "codex-task",
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--no-copy" in result.stdout
+
+
 def test_settings_env(tmp_path, monkeypatch):
     env_file = tmp_path / ".env"
     env_file.write_text("GITHUB_TOKEN=test\nLOG_SIZE_THRESHOLD=123\n")

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -145,6 +145,23 @@ def test_codex_task_command_copies_to_clipboard(monkeypatch, capsys):
     assert copied["text"] == "MD"
 
 
+def test_codex_task_command_no_copy(monkeypatch, capsys):
+    async def fake_process(url: str, settings: Settings) -> str:
+        return "MD"
+
+    monkeypatch.setattr("f2clipboard.codex_task._process_task", fake_process)
+    called: list[str] = []
+
+    def fake_copy(text: str) -> None:
+        called.append(text)
+
+    monkeypatch.setattr("f2clipboard.codex_task.clipboard.copy", fake_copy)
+    codex_task_command("http://task", copy_to_clipboard=False)
+    out = capsys.readouterr().out
+    assert "MD" in out
+    assert not called
+
+
 @pytest.mark.vcr()
 def test_fetch_task_html_records_example():
     html = asyncio.run(_fetch_task_html("https://example.com"))


### PR DESCRIPTION
what: allow skipping clipboard copy via --no-copy flag
why: scripts can run without mutating clipboard contents
how to test:
  python -m pre_commit run --files f2clipboard/codex_task.py README.md \
  tests/test_codex_task.py tests/test_basic.py
  pytest -q


------
https://chatgpt.com/codex/tasks/task_e_6893c0f8c648832f90a6cc0557bf1355