### PR TITLE
🔐: redact OpenAI API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ f2clipboard files --dir path/to/project
 ### M2 (hardening)
 - [ ] Playwright headless login for private Codex tasks.
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
-- [x] Secret scanning & redaction (via custom regex). 💯
+- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_` and OpenAI `sk-` keys). 💯
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯

--- a/f2clipboard/secret.py
+++ b/f2clipboard/secret.py
@@ -7,6 +7,7 @@ from typing import Pattern
 
 SECRET_PATTERNS: list[Pattern[str]] = [
     re.compile(r"ghp_[A-Za-z0-9]{36}"),
+    re.compile(r"sk-[A-Za-z0-9]{32,}"),
     re.compile(
         r"(?i)(?P<key>[\w-]*(?:api|token|secret|password)[\w-]*)\s*(?P<sep>[:=])\s*(?P<value>[A-Za-z0-9-_.]{8,})"
     ),
@@ -23,6 +24,8 @@ def redact_secrets(text: str) -> str:
         token = match.group(0)
         if token.startswith("ghp_"):
             return "ghp_REDACTED"
+        if token.startswith("sk-"):
+            return "sk-REDACTED"
         return "***"
 
     for pattern in SECRET_PATTERNS:

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -7,11 +7,13 @@ from f2clipboard.secret import redact_secrets
 
 def test_redact_secrets():
     token = "ghp_" + "a" * 36
-    text = f"TOKEN=abcdef123456 {token}"
+    openai_token = "sk-" + "b" * 48
+    text = f"TOKEN=abcdef123456 {token} {openai_token}"
     redacted = redact_secrets(text)
     assert "abcdef123456" not in redacted
     assert "ghp_REDACTED" in redacted
     assert "TOKEN=***" in redacted
+    assert "sk-REDACTED" in redacted
 
 
 def test_process_task_redacts(monkeypatch):


### PR DESCRIPTION
## Summary
- extend secret scanner to handle OpenAI `sk-` tokens
- document GitHub and OpenAI key redaction

## Testing
- `pre-commit run --files f2clipboard/secret.py tests/test_secret.py README.md`
- `pytest -q`
- `npm run lint` *(fails: package.json missing)*
- `npm run test:ci` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6893c0f8c648832f90a6cc0557bf1355