### PR TITLE
Add chat2prompt command for generating prompts from shared chats

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ To skip copying to the clipboard, pass ``--no-clipboard``:
 f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --no-clipboard
 ```
 
+Generate a prompt that reads a shared chat transcript and implements any code or configuration
+changes it mentions:
+
+```bash
+f2clipboard chat2prompt https://chatgpt.com/share/abcdefg
+```
+
+Specify a different platform with ``--platform``:
+
+```bash
+f2clipboard chat2prompt https://chatgpt.com/share/abcdefg --platform anthropic
+```
+
 Copy selected files from a local repository:
 
 ```bash

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -3,6 +3,7 @@ from importlib.metadata import PackageNotFoundError, entry_points, version
 
 from typer import Typer
 
+from .chat2prompt import chat2prompt_command
 from .codex_task import codex_task_command
 from .files import files_command
 
@@ -13,6 +14,7 @@ except PackageNotFoundError:  # pragma: no cover
 
 app = Typer(add_completion=False, help="Flows \u2192 clipboard automation CLI")
 app.command("codex-task")(codex_task_command)
+app.command("chat2prompt")(chat2prompt_command)
 app.command("files")(files_command)
 
 

--- a/f2clipboard/chat2prompt.py
+++ b/f2clipboard/chat2prompt.py
@@ -1,0 +1,46 @@
+"""Convert chat transcripts into prompts for coding assistants."""
+
+from __future__ import annotations
+
+import re
+
+import clipboard
+import httpx
+import typer
+
+
+def _extract_text(html: str) -> str:
+    """Return plain text from HTML."""
+    text = re.sub(r"<[^>]+>", "", html)
+    return text.strip()
+
+
+def _fetch_transcript(url: str) -> str:
+    """Download transcript text from a shared chat URL."""
+    response = httpx.get(url, follow_redirects=True)
+    response.raise_for_status()
+    return _extract_text(response.text)
+
+
+def _build_prompt(transcript: str, platform: str) -> str:
+    return (
+        f"You are given the following {platform} chat transcript. "
+        "Read it and fully implement any code or configuration changes discussed. "
+        "Return the complete implementation.\n\n"
+        f"{transcript}"
+    )
+
+
+def chat2prompt_command(
+    url: str = typer.Argument(..., help="Chat transcript URL"),
+    platform: str = typer.Option("codex", "--platform", "-p", help="Target platform"),
+    copy_to_clipboard: bool = typer.Option(
+        True, "--clipboard/--no-clipboard", help="Copy prompt to clipboard."
+    ),
+) -> None:
+    """Create a coding prompt from a chat transcript and copy it to the clipboard."""
+    transcript = _fetch_transcript(url)
+    prompt = _build_prompt(transcript, platform)
+    if copy_to_clipboard:
+        clipboard.copy(prompt)
+    typer.echo(prompt)

--- a/tests/test_chat2prompt.py
+++ b/tests/test_chat2prompt.py
@@ -1,0 +1,28 @@
+import clipboard
+
+from f2clipboard.chat2prompt import _extract_text, chat2prompt_command
+
+
+def test_extract_text_removes_html():
+    html = "<div>Hello <b>World</b></div>"
+    assert _extract_text(html) == "Hello World"
+
+
+def test_chat2prompt_command_copies_prompt(monkeypatch, capsys):
+    def fake_fetch(url: str) -> str:
+        assert url == "http://chat"
+        return "User: Hi\nAssistant: Hello"
+
+    monkeypatch.setattr("f2clipboard.chat2prompt._fetch_transcript", fake_fetch)
+
+    copied: dict[str, str] = {}
+
+    def fake_copy(text: str) -> None:
+        copied["text"] = text
+
+    monkeypatch.setattr(clipboard, "copy", fake_copy)
+    chat2prompt_command("http://chat", platform="anthropic")
+    out = capsys.readouterr().out
+    assert "anthropic" in out
+    assert "User: Hi" in copied["text"]
+    assert "implement" in copied["text"]


### PR DESCRIPTION
## Summary
- refine chat2prompt prompt to request full code/config implementation
- document updated behavior and extend tests to cover new wording

## Testing
- `pre-commit run --files f2clipboard/chat2prompt.py tests/test_chat2prompt.py README.md`
- `pytest -q`
- `detect-secrets scan /tmp/diff.patch`


------
https://chatgpt.com/codex/tasks/task_e_6893f8af2ef4832fb91d69e27070db62