### PR TITLE
✨: add CLI version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ Copy selected files from a local repository:
 f2clipboard files --dir path/to/project
 ```
 
+Check the installed version:
+
+```bash
+f2clipboard --version
+```
+
 ## Plugins
 
 f2clipboard loads plugins registered under the `f2clipboard.plugins` entry-point group. A plugin

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -1,6 +1,7 @@
 import logging
 from importlib.metadata import PackageNotFoundError, entry_points, version
 
+import typer
 from typer import Typer
 
 from .codex_task import codex_task_command
@@ -14,6 +15,27 @@ except PackageNotFoundError:  # pragma: no cover
 app = Typer(add_completion=False, help="Flows \u2192 clipboard automation CLI")
 app.command("codex-task")(codex_task_command)
 app.command("files")(files_command)
+
+
+def _version_callback(value: bool) -> None:
+    """Print the package version and exit."""
+    if value:
+        typer.echo(__version__)
+        raise typer.Exit()
+
+
+@app.callback()
+def _main(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        help="Show the application's version and exit.",
+        callback=_version_callback,
+        is_eager=True,
+    ),
+) -> None:
+    """Main entry point handling global options."""
+    return
 
 
 def _load_plugins() -> None:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -26,6 +26,21 @@ def test_cli_help():
     assert "files" in result.stdout
 
 
+def test_cli_version():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "f2clipboard.cli",
+            "--version",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert __version__ in result.stdout
+
+
 def test_settings_env(tmp_path, monkeypatch):
     env_file = tmp_path / ".env"
     env_file.write_text("GITHUB_TOKEN=test\nLOG_SIZE_THRESHOLD=123\n")


### PR DESCRIPTION
what: expose --version option for CLI
why: allow users to verify installed version
how to test: pre-commit run --files f2clipboard/__init__.py tests/test_basic.py README.md && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_6893e28c343c832fb1b8472dc78d7498