### PR TITLE
Add Playwright login for private Codex tasks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,5 @@
 GITHUB_TOKEN=ghp_xxx           # scopes: repo, read:org
 OPENAI_API_KEY=sk-xxx          # optional if using Anthropic
 ANTHROPIC_API_KEY=claude-xxx   # optional alternative
+CODEX_COOKIE=cookie-xxx        # optional; enables Playwright login
 LOG_SIZE_THRESHOLD=150000      # bytes; logs bigger than this get summarised

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ f2clipboard files --dir path/to/project
 - [x] Write Markdown artefact to `stdout` **and** clipboard. 💯
 
 ### M2 (hardening)
-- [ ] Playwright headless login for private Codex tasks.
+- [x] Playwright headless login for private Codex tasks. 💯
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
 - [x] Secret scanning & redaction (via custom regex; GitHub `ghp_` and OpenAI `sk-` keys). 💯
 
@@ -69,6 +69,7 @@ cd f2clipboard
 pip install -e ".[dev]"
 cp .env.example .env  # fill in your tokens
 # Set OPENAI_API_KEY or ANTHROPIC_API_KEY for log summarisation
+# Set CODEX_COOKIE to access private Codex tasks
 ```
 
 Generate a Markdown snippet for a Codex task:

--- a/f2clipboard/config.py
+++ b/f2clipboard/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     github_token: str | None = Field(default=None, alias="GITHUB_TOKEN")
     openai_api_key: str | None = Field(default=None, alias="OPENAI_API_KEY")
     anthropic_api_key: str | None = Field(default=None, alias="ANTHROPIC_API_KEY")
+    codex_cookie: str | None = Field(default=None, alias="CODEX_COOKIE")
     log_size_threshold: int = Field(default=150000, alias="LOG_SIZE_THRESHOLD")
 
     class Config:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
     "httpx",
+    "playwright",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -28,8 +28,11 @@ def test_cli_help():
 
 def test_settings_env(tmp_path, monkeypatch):
     env_file = tmp_path / ".env"
-    env_file.write_text("GITHUB_TOKEN=test\nLOG_SIZE_THRESHOLD=123\n")
+    env_file.write_text(
+        "GITHUB_TOKEN=test\nLOG_SIZE_THRESHOLD=123\nCODEX_COOKIE=cookie\n"  # pragma: allowlist secret
+    )
     monkeypatch.chdir(tmp_path)
     settings = Settings()
     assert settings.github_token == "test"
     assert settings.log_size_threshold == 123
+    assert settings.codex_cookie == "cookie"

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -8,16 +8,16 @@ from f2clipboard.secret import redact_secrets
 def test_redact_secrets():
     token = "ghp_" + "a" * 36
     openai_token = "sk-" + "b" * 48
-    text = f"TOKEN=abcdef123456 {token} {openai_token}"
+    text = f"TOKEN=abcdef123456 {token} {openai_token}"  # pragma: allowlist secret
     redacted = redact_secrets(text)
-    assert "abcdef123456" not in redacted
+    assert "abcdef123456" not in redacted  # pragma: allowlist secret
     assert "ghp_REDACTED" in redacted
     assert "TOKEN=***" in redacted
     assert "sk-REDACTED" in redacted
 
 
 def test_process_task_redacts(monkeypatch):
-    async def fake_html(url: str) -> str:
+    async def fake_html(url: str, cookie: str | None = None) -> str:
         return '<a href="https://github.com/o/r/pull/1">PR</a>'
 
     async def fake_runs(pr_url: str, token: str | None):
@@ -27,7 +27,7 @@ def test_process_task_redacts(monkeypatch):
         return "TOKEN=abcdef123456"
 
     async def fake_summary(text: str, settings: Settings) -> str:
-        assert "abcdef123456" not in text
+        assert "abcdef123456" not in text  # pragma: allowlist secret
         return "SUMMARY"
 
     monkeypatch.setattr("f2clipboard.codex_task._fetch_task_html", fake_html)
@@ -38,5 +38,5 @@ def test_process_task_redacts(monkeypatch):
     settings = Settings()
     settings.log_size_threshold = 0
     result = asyncio.run(_process_task("http://task", settings))
-    assert "abcdef123456" not in result
+    assert "abcdef123456" not in result  # pragma: allowlist secret
     assert "SUMMARY" in result


### PR DESCRIPTION
## Summary
- use Playwright with `CODEX_COOKIE` to load private Codex task pages
- document `CODEX_COOKIE` and include Playwright dependency
- test authenticated HTML fetch and env loading

## Testing
- `pre-commit run --files README.md .env.example pyproject.toml f2clipboard/config.py f2clipboard/codex_task.py tests/test_codex_task.py tests/test_basic.py tests/test_secret.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893e289f96c832f9de3565334895736