### PR TITLE
✨ : – add configurable log summarisation threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ To skip copying to the clipboard, pass ``--no-clipboard``:
 f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --no-clipboard
 ```
 
+Adjust the log size threshold for summarisation with ``--log-size-threshold``:
+
+```bash
+f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --log-size-threshold 200000
+```
+
 Generate a prompt that reads a shared chat transcript and implements any code or configuration
 changes it mentions:
 

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import gzip
 import re
-from typing import Any
+from typing import Annotated, Any
 
 import clipboard
 import httpx
@@ -150,13 +150,23 @@ def codex_task_command(
         "--clipboard/--no-clipboard",
         help="Copy result to the system clipboard.",
     ),
+    log_size_threshold: Annotated[
+        int | None,
+        typer.Option(
+            "--log-size-threshold",
+            help="Summarise logs larger than this many bytes.",
+        ),
+    ] = None,
 ) -> None:
     """Parse a Codex task page and print any failing GitHub checks.
 
     The generated Markdown is copied to the clipboard unless ``--no-clipboard`` is passed.
     """
     typer.echo(f"Parsing Codex task page: {url}…")
-    settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
+    if log_size_threshold is not None:
+        settings = Settings(LOG_SIZE_THRESHOLD=log_size_threshold)
+    else:
+        settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
     result = asyncio.run(_process_task(url, settings))
     if copy_to_clipboard:
         clipboard.copy(result)

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -180,6 +180,16 @@ def test_codex_task_command_skips_clipboard(monkeypatch, capsys):
     assert not copied
 
 
+def test_codex_task_command_overrides_threshold(monkeypatch, capsys):
+    async def fake_process(url: str, settings: Settings) -> str:
+        return str(settings.log_size_threshold)
+
+    monkeypatch.setattr("f2clipboard.codex_task._process_task", fake_process)
+    codex_task_command("http://task", copy_to_clipboard=False, log_size_threshold=1234)
+    out = capsys.readouterr().out
+    assert "1234" in out
+
+
 @pytest.mark.vcr()
 def test_fetch_task_html_records_example():
     html = asyncio.run(_fetch_task_html("https://example.com"))


### PR DESCRIPTION
Allow overriding log-size limit via CLI and summarise large logs.
Includes documentation and tests for threshold override.

Test: pre-commit run --files updated && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6894374c6f68832fa186dbca0eadedf9