### PR TITLE
✨ : summarise large logs with CLI threshold

### DIFF
--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -150,13 +150,21 @@ def codex_task_command(
         "--clipboard/--no-clipboard",
         help="Copy result to the system clipboard.",
     ),
+    log_size_threshold: int | None = typer.Option(
+        None,
+        "--log-size-threshold",
+        help="Summarise logs larger than this many bytes.",
+    ),
 ) -> None:
     """Parse a Codex task page and print any failing GitHub checks.
 
     The generated Markdown is copied to the clipboard unless ``--no-clipboard`` is passed.
+    Use ``--log-size-threshold`` to override the summarisation threshold.
     """
     typer.echo(f"Parsing Codex task page: {url}…")
     settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
+    if log_size_threshold is not None:
+        settings.log_size_threshold = log_size_threshold
     result = asyncio.run(_process_task(url, settings))
     if copy_to_clipboard:
         clipboard.copy(result)

--- a/f2clipboard/config.py
+++ b/f2clipboard/config.py
@@ -11,7 +11,11 @@ class Settings(BaseSettings):
     openai_api_key: str | None = Field(default=None, alias="OPENAI_API_KEY")
     anthropic_api_key: str | None = Field(default=None, alias="ANTHROPIC_API_KEY")
     codex_cookie: str | None = Field(default=None, alias="CODEX_COOKIE")
-    log_size_threshold: int = Field(default=150000, alias="LOG_SIZE_THRESHOLD")
+    log_size_threshold: int = Field(
+        default=150_000,
+        alias="LOG_SIZE_THRESHOLD",
+        description="Summarise logs larger than this many bytes",
+    )
 
     class Config:
         env_file = ".env"

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -180,6 +180,16 @@ def test_codex_task_command_skips_clipboard(monkeypatch, capsys):
     assert not copied
 
 
+def test_codex_task_command_overrides_threshold(monkeypatch, capsys):
+    async def fake_process(url: str, settings: Settings) -> str:
+        return f"threshold {settings.log_size_threshold}"
+
+    monkeypatch.setattr("f2clipboard.codex_task._process_task", fake_process)
+    codex_task_command("http://task", log_size_threshold=123, copy_to_clipboard=False)
+    out = capsys.readouterr().out
+    assert "threshold 123" in out
+
+
 @pytest.mark.vcr()
 def test_fetch_task_html_records_example():
     html = asyncio.run(_fetch_task_html("https://example.com"))


### PR DESCRIPTION
what: summarise oversized check-run logs and allow CLI threshold override.
why: keep output concise while retaining early log context.
how to test: pre-commit run --files f2clipboard/codex_task.py f2clipboard/config.py tests/test_codex_task.py && pytest -q


------
https://chatgpt.com/codex/tasks/task_e_6894374c6f68832fa186dbca0eadedf9