### PR TITLE
🔐 : redact Slack tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ f2clipboard files --dir path/to/project
 ### M2 (hardening)
 - [x] Playwright headless login for private Codex tasks. 💯
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
-- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_` and OpenAI `sk-` keys). 💯
+- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`, OpenAI `sk-`, and Slack `xoxb-` keys). 💯
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯

--- a/f2clipboard/secret.py
+++ b/f2clipboard/secret.py
@@ -8,6 +8,7 @@ from typing import Pattern
 SECRET_PATTERNS: list[Pattern[str]] = [
     re.compile(r"ghp_[A-Za-z0-9]{36}"),
     re.compile(r"sk-[A-Za-z0-9]{32,}"),
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
     re.compile(
         r"(?i)(?P<key>[\w-]*(?:api|token|secret|password)[\w-]*)\s*(?P<sep>[:=])\s*(?P<value>[A-Za-z0-9-_.]{8,})"
     ),
@@ -26,6 +27,9 @@ def redact_secrets(text: str) -> str:
             return "ghp_REDACTED"
         if token.startswith("sk-"):
             return "sk-REDACTED"
+        if token.startswith("xox"):
+            prefix = token.split("-", 1)[0]
+            return f"{prefix}-REDACTED"
         return "***"
 
     for pattern in SECRET_PATTERNS:

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -8,12 +8,14 @@ from f2clipboard.secret import redact_secrets
 def test_redact_secrets():
     token = "ghp_" + "a" * 36
     openai_token = "sk-" + "b" * 48
-    text = f"TOKEN=abcdef123456 {token} {openai_token}"  # pragma: allowlist secret
+    slack_token = "xoxb-" + "c" * 40
+    text = f"TOKEN=abcdef123456 {token} {openai_token} {slack_token}"  # pragma: allowlist secret
     redacted = redact_secrets(text)
     assert "abcdef123456" not in redacted  # pragma: allowlist secret
     assert "ghp_REDACTED" in redacted
     assert "TOKEN=***" in redacted
     assert "sk-REDACTED" in redacted
+    assert "xoxb-REDACTED" in redacted
 
 
 def test_process_task_redacts(monkeypatch):


### PR DESCRIPTION
what: detect and mask Slack xoxb- tokens
why: prevent leaking Slack credentials
how: pre-commit run --files f2clipboard/secret.py tests/test_secret.py
     README.md; pytest
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68943739e5c8832f876e0bab5f24c132