### PR TITLE
🔒 : – redact fine-grained GitHub tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ f2clipboard files --dir path/to/project
 ### M2 (hardening)
 - [x] Playwright headless login for private Codex tasks. 💯
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
-- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_` and OpenAI `sk-` keys). 💯
+- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`github_pat_` and OpenAI `sk-` keys). 💯
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯

--- a/f2clipboard/secret.py
+++ b/f2clipboard/secret.py
@@ -7,6 +7,7 @@ from typing import Pattern
 
 SECRET_PATTERNS: list[Pattern[str]] = [
     re.compile(r"ghp_[A-Za-z0-9]{36}"),
+    re.compile(r"github_pat_[A-Za-z0-9_]{22,}"),
     re.compile(r"sk-[A-Za-z0-9]{32,}"),
     re.compile(
         r"(?i)(?P<key>[\w-]*(?:api|token|secret|password)[\w-]*)\s*(?P<sep>[:=])\s*(?P<value>[A-Za-z0-9-_.]{8,})"
@@ -24,6 +25,8 @@ def redact_secrets(text: str) -> str:
         token = match.group(0)
         if token.startswith("ghp_"):
             return "ghp_REDACTED"
+        if token.startswith("github_pat_"):
+            return "github_pat_REDACTED"
         if token.startswith("sk-"):
             return "sk-REDACTED"
         return "***"

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -16,6 +16,13 @@ def test_redact_secrets():
     assert "sk-REDACTED" in redacted
 
 
+def test_redact_github_pat():
+    token = "github_pat_" + "c" * 50  # pragma: allowlist secret
+    redacted = redact_secrets(token)
+    assert "c" * 10 not in redacted  # pragma: allowlist secret
+    assert "github_pat_REDACTED" in redacted
+
+
 def test_process_task_redacts(monkeypatch):
     async def fake_html(url: str, cookie: str | None = None) -> str:
         return '<a href="https://github.com/o/r/pull/1">PR</a>'


### PR DESCRIPTION
What: mask github_pat_ secrets and test redaction; update docs.
Why: ensure fine-grained GitHub tokens are sanitized.
How to test: pre-commit run --files f2clipboard/secret.py tests/test_secret.py README.md && pytest
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68943739e5c8832f876e0bab5f24c132