### PR TITLE
✨: unescape HTML entities in chat transcripts

### DIFF
--- a/f2clipboard/chat2prompt.py
+++ b/f2clipboard/chat2prompt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 import re
 
 import clipboard
@@ -9,10 +10,10 @@ import httpx
 import typer
 
 
-def _extract_text(html: str) -> str:
+def _extract_text(html_text: str) -> str:
     """Return plain text from HTML."""
-    text = re.sub(r"<[^>]+>", "", html)
-    return text.strip()
+    text = re.sub(r"<[^>]+>", "", html_text)
+    return html.unescape(text).strip()
 
 
 def _fetch_transcript(url: str) -> str:

--- a/tests/test_chat2prompt.py
+++ b/tests/test_chat2prompt.py
@@ -8,6 +8,11 @@ def test_extract_text_removes_html():
     assert _extract_text(html) == "Hello World"
 
 
+def test_extract_text_unescapes_entities():
+    html = "Tom &amp; Jerry"
+    assert _extract_text(html) == "Tom & Jerry"
+
+
 def test_chat2prompt_command_copies_prompt(monkeypatch, capsys):
     def fake_fetch(url: str) -> str:
         assert url == "http://chat"


### PR DESCRIPTION
## Summary
- handle HTML entities in chat2prompt
- test unescaping of HTML entities

## Testing
- `pre-commit run --files f2clipboard/chat2prompt.py tests/test_chat2prompt.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68943739e5c8832f876e0bab5f24c132