### PR TITLE
✨ : – copy codex-task output to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Generate a Markdown snippet for a Codex task:
 
 ```bash
 f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123
+pbpaste > failing-checks.md  # Linux: xclip -o -selection clipboard > failing-checks.md
 ```
 
 The resulting Markdown is printed to your terminal and copied to the clipboard.

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -7,8 +7,8 @@ import gzip
 import re
 from typing import Any
 
-import clipboard
 import httpx
+import pyperclip
 import typer
 
 from .config import Settings
@@ -159,5 +159,10 @@ def codex_task_command(
     settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
     result = asyncio.run(_process_task(url, settings))
     if copy_to_clipboard:
-        clipboard.copy(result)
+        try:
+            pyperclip.copy(result)
+        except pyperclip.PyperclipException as exc:  # pragma: no cover - env specific
+            typer.secho(
+                f"Warning: could not copy to clipboard: {exc}", fg="yellow", err=True
+            )
     typer.echo(result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 requires-python = ">=3.8"
 dependencies = [
     "clipboard",
+    "pyperclip",
     "typer>=0.9.0",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -1,6 +1,7 @@
 import asyncio
 import gzip
 
+import pyperclip
 import pytest
 
 from f2clipboard.codex_task import (
@@ -156,7 +157,7 @@ def test_codex_task_command_copies_to_clipboard(monkeypatch, capsys):
     def fake_copy(text: str) -> None:
         copied["text"] = text
 
-    monkeypatch.setattr("f2clipboard.codex_task.clipboard.copy", fake_copy)
+    monkeypatch.setattr("f2clipboard.codex_task.pyperclip.copy", fake_copy)
     codex_task_command("http://task")
     out = capsys.readouterr().out
     assert "MD" in out
@@ -173,11 +174,27 @@ def test_codex_task_command_skips_clipboard(monkeypatch, capsys):
     def fake_copy(text: str) -> None:
         copied["text"] = text
 
-    monkeypatch.setattr("f2clipboard.codex_task.clipboard.copy", fake_copy)
+    monkeypatch.setattr("f2clipboard.codex_task.pyperclip.copy", fake_copy)
     codex_task_command("http://task", copy_to_clipboard=False)
     out = capsys.readouterr().out
     assert "MD" in out
     assert not copied
+
+
+def test_codex_task_command_warns_on_clipboard_error(monkeypatch, capsys):
+    async def fake_process(url: str, settings: Settings) -> str:
+        return "MD"
+
+    monkeypatch.setattr("f2clipboard.codex_task._process_task", fake_process)
+
+    def fake_copy(text: str) -> None:
+        raise pyperclip.PyperclipException("no clipboard")
+
+    monkeypatch.setattr("f2clipboard.codex_task.pyperclip.copy", fake_copy)
+    codex_task_command("http://task")
+    captured = capsys.readouterr()
+    assert "MD" in captured.out
+    assert "Warning" in captured.err
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
## Summary
- send codex-task markdown to stdout and clipboard with pyperclip
- warn instead of failing when clipboard is missing
- document clipboard workflow in Getting Started

## Testing
- `pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894374ee930832f9da0f6d7e5559083