### PR TITLE
✅ : improve Codex PR URL extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ f2clipboard files --dir path/to/project
 ### M0 (bootstrap)
 - [x] Ship basic CLI with `codex-task` command and help text.
 - [x] Support GitHub personal-access tokens via `.env`.
-- [x] Fetch PR URL from Codex task HTML (unauthenticated test page).
+- [x] Fetch PR URL from Codex task HTML (unauthenticated test page). 💯
 
 ### M1 (minimum lovable product)
 - [x] Parse check-suites with GitHub REST v3. 💯

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -58,8 +58,14 @@ async def _fetch_task_html(url: str, cookie: str | None = None) -> str:
 
 
 def _extract_pr_url(html: str) -> str | None:
-    """Return the first GitHub PR URL found in the given HTML."""
-    match = re.search(r'href="(https://github.com/[^"]+/pull/\d+)"', html)
+    """Return the first GitHub PR URL found in the given HTML.
+
+    The Codex task page includes a "View PR" link pointing to the associated
+    GitHub pull request. Codex's markup may use single or double quotes around
+    attribute values, so the regular expression accounts for both variants.
+    """
+
+    match = re.search(r"href=['\"](https://github.com/[^'\"]+/pull/\d+)['\"]", html)
     return match.group(1) if match else None
 
 

--- a/tests/test_pr_url_extraction.py
+++ b/tests/test_pr_url_extraction.py
@@ -1,0 +1,18 @@
+import pytest
+
+from f2clipboard.codex_task import _extract_pr_url
+
+
+@pytest.mark.parametrize(
+    "html",
+    [
+        '<a href="https://github.com/owner/repo/pull/123">View PR</a>',
+        "<a href='https://github.com/owner/repo/pull/123'>View PR</a>",
+    ],
+)
+def test_extract_pr_url_success(html: str) -> None:
+    assert _extract_pr_url(html) == "https://github.com/owner/repo/pull/123"
+
+
+def test_extract_pr_url_missing() -> None:
+    assert _extract_pr_url("<html></html>") is None


### PR DESCRIPTION
what: broaden PR link detection and document roadmap.
why: ensure codex-task handles both quoting styles.
how to test: pre-commit run --files f2clipboard/codex_task.py tests/test_pr_url_extraction.py README.md && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6894373f196c832fa7b7c6548398ab07