### PR TITLE
✨: – test codex-task help and tidy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ f2clipboard files --dir path/to/project
 
 ## Roadmap
 ### M0 (bootstrap)
-- [x] Ship basic CLI with `codex-task` command and help text.
+- [x] Ship basic CLI with `codex-task` command and help text. 💯
 - [x] Support GitHub personal-access tokens via `.env`. 💯
 - [x] Fetch PR URL from Codex task HTML (unauthenticated test page). 💯
 
@@ -80,6 +80,7 @@ f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123
 ```
 
 The resulting Markdown is printed to your terminal and copied to the clipboard.
+For a list of available options, run ``f2clipboard codex-task --help``.
 To skip copying to the clipboard, pass ``--no-clipboard``:
 
 ```bash

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -178,9 +178,6 @@ def codex_task_command(
     Use ``--log-size-threshold`` to override the summarisation threshold.
     """
     typer.echo(f"Parsing Codex task page: {url}…")
-    settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
-    if log_size_threshold is not None:
-        settings.log_size_threshold = log_size_threshold
     if log_size_threshold is not None:
         settings = Settings(LOG_SIZE_THRESHOLD=log_size_threshold)
     else:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -41,6 +41,25 @@ def test_cli_version():
     assert __version__ in result.stdout
 
 
+def test_codex_task_help():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "f2clipboard.cli",
+            "codex-task",
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "Parse a Codex task page" in result.stdout
+    assert "--clipboard" in result.stdout
+    assert "--no-clipboard" in result.stdout
+    assert "--log-size-threshold" in result.stdout
+
+
 def test_settings_env(tmp_path, monkeypatch):
     env_file = tmp_path / ".env"
     env_file.write_text(


### PR DESCRIPTION
what: add CLI help test, clean codex-task settings, document help usage.
why: expose codex-task options and avoid redundant configuration.
how to test: pre-commit run --files f2clipboard/codex_task.py tests/test_basic.py README.md && pytest -q.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689462760204832f9353de104fd27870