### PR TITLE
🐛 : preserve whitespace in secret redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ f2clipboard files --dir path/to/project
 ### M2 (hardening)
 - [x] Playwright headless login for private Codex tasks. 💯
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
-- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`github_pat_`, OpenAI `sk-`, and Slack `xoxb-` keys). 💯
+- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`github_pat_`, OpenAI
+  `sk-`, and Slack `xoxb-` keys) while preserving whitespace around `=` and `:`. 💯
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -25,6 +25,13 @@ def test_redact_github_pat():
     assert "github_pat_REDACTED" in redacted
 
 
+def test_redact_preserves_whitespace():
+    text = "TOKEN = abcdef123456\napi_key:\tsecret1234"  # pragma: allowlist secret
+    redacted = redact_secrets(text)
+    assert "TOKEN = ***" in redacted
+    assert "api_key:\t***" in redacted
+
+
 def test_process_task_redacts(monkeypatch):
     async def fake_html(url: str, cookie: str | None = None) -> str:
         return '<a href="https://github.com/o/r/pull/1">PR</a>'


### PR DESCRIPTION
what: keep spacing around '=' and ':' when masking secrets
why: env-style configs looked mangled
how to test:
  pre-commit run --files tests/test_secret.py f2clipboard/secret.py README.md
  pytest -q

------
https://chatgpt.com/codex/tasks/task_e_689462710a2c832f8da682eb8a858064