### PR TITLE
♻️ : streamline Settings init in codex_task

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Adjust the log size threshold for summarisation with ``--log-size-threshold``:
 f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --log-size-threshold 200000
 ```
 
+The default threshold can also be set via the ``LOG_SIZE_THRESHOLD`` environment variable in
+your ``.env`` file.
+
 Generate a prompt that reads a shared chat transcript and implements any code or configuration
 changes it mentions:
 

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -178,9 +178,6 @@ def codex_task_command(
     Use ``--log-size-threshold`` to override the summarisation threshold.
     """
     typer.echo(f"Parsing Codex task page: {url}…")
-    settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
-    if log_size_threshold is not None:
-        settings.log_size_threshold = log_size_threshold
     if log_size_threshold is not None:
         settings = Settings(LOG_SIZE_THRESHOLD=log_size_threshold)
     else:

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -223,6 +223,24 @@ def test_codex_task_command_overrides_threshold(monkeypatch, capsys):
     assert "1234" in out
 
 
+def test_codex_task_command_initialises_settings_once(monkeypatch):
+    calls: list[int | None] = []
+
+    class DummySettings:
+        def __init__(self, LOG_SIZE_THRESHOLD: int = 150_000):
+            calls.append(LOG_SIZE_THRESHOLD)
+            self.log_size_threshold = LOG_SIZE_THRESHOLD
+
+    async def fake_process(url: str, settings: DummySettings) -> str:
+        return ""
+
+    monkeypatch.setattr("f2clipboard.codex_task.Settings", DummySettings)
+    monkeypatch.setattr("f2clipboard.codex_task._process_task", fake_process)
+
+    codex_task_command("http://task", copy_to_clipboard=False, log_size_threshold=5)
+    assert calls == [5]
+
+
 @pytest.mark.vcr()
 def test_fetch_task_html_records_example():
     html = asyncio.run(_fetch_task_html("https://example.com"))


### PR DESCRIPTION
what: ensure Settings is created once and document LOG_SIZE_THRESHOLD
why: remove redundant work and clarify env-based configuration
how to test:
- pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py README.md
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_689462710a2c832f8da682eb8a858064