### PR TITLE
🐛: add PyYAML runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pydantic-settings>=2.0",
     "httpx",
     "playwright",
+    "pyyaml",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- include PyYAML in default dependencies to satisfy tests

## Testing
- `pre-commit run --files pyproject.toml`
- `pytest -q`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68959238efd4832fbbe7a0d6d3bba633