### PR TITLE
🐛: ensure help renders in narrow terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123
 ```
 
 The resulting Markdown is printed to your terminal and copied to the clipboard.
-For a list of available options, run ``f2clipboard codex-task --help``.
+For a list of available options, run ``f2clipboard codex-task --help``. The CLI enforces a minimum
+help width of 80 characters so options render correctly in narrow environments such as CI.
 To skip copying to the clipboard, pass ``--no-clipboard``:
 
 ```bash

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -1,12 +1,16 @@
 import logging
+import os
 from importlib.metadata import PackageNotFoundError, entry_points, version
 
-import typer
-from typer import Typer
+# Ensure Rich renders help at a reasonable width even in narrow environments
+os.environ.setdefault("TERMINAL_WIDTH", "80")
 
-from .chat2prompt import chat2prompt_command
-from .codex_task import codex_task_command
-from .files import files_command
+import typer  # noqa: E402
+from typer import Typer  # noqa: E402
+
+from .chat2prompt import chat2prompt_command  # noqa: E402
+from .codex_task import codex_task_command  # noqa: E402
+from .files import files_command  # noqa: E402
 
 try:
     __version__ = version("f2clipboard")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -52,6 +53,7 @@ def test_codex_task_help():
         ],
         capture_output=True,
         text=True,
+        env={**os.environ, "COLUMNS": "1"},
     )
     assert result.returncode == 0
     assert "Parse a Codex task page" in result.stdout


### PR DESCRIPTION
## Summary
- set TERMINAL_WIDTH to keep Typer help readable
- test help output under minimal COLUMNS
- document enforced 80-column help width

## Testing
- `pre-commit run --files README.md f2clipboard/__init__.py tests/test_basic.py`
- `pytest -q`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6895995b22a0832fbe9166c0724c193f