### PR TITLE
🐛: ensure codex-task help shows clipboard flags

### DIFF
--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -1,8 +1,10 @@
 import logging
+import shutil
 from importlib.metadata import PackageNotFoundError, entry_points, version
 
 import typer
-from typer import Typer
+from rich.console import Console
+from typer import Typer, rich_utils
 
 from .chat2prompt import chat2prompt_command
 from .codex_task import codex_task_command
@@ -12,6 +14,16 @@ try:
     __version__ = version("f2clipboard")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0+dev"
+
+# Ensure CLI help renders at a reasonable width even when the terminal reports
+# an extremely small value (e.g. ``COLUMNS=1``). Typer uses a global Rich
+# console for formatting help text, and Rich clamps the width to the detected
+# terminal size. Calculate a safe minimum width and replace the default console
+# so option strings like ``--clipboard`` are not split across lines.
+_MIN_WIDTH = 80
+_width = max(shutil.get_terminal_size(fallback=(_MIN_WIDTH, 24)).columns, _MIN_WIDTH)
+rich_utils.console = Console(width=_width)
+rich_utils.MAX_WIDTH = _width
 
 app = Typer(add_completion=False, help="Flows \u2192 clipboard automation CLI")
 app.command("codex-task")(codex_task_command)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -52,6 +53,7 @@ def test_codex_task_help():
         ],
         capture_output=True,
         text=True,
+        env={**os.environ, "COLUMNS": "1"},
     )
     assert result.returncode == 0
     assert "Parse a Codex task page" in result.stdout


### PR DESCRIPTION
## What
- replace Typer's global console with one wide enough to preserve option flags

## Why
- environments that report `COLUMNS=1` split `--clipboard` across lines, failing help tests

## How to test
- `python -m pre_commit run --files f2clipboard/__init__.py tests/test_basic.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68959c99abd8832fb61333fd0cffaae7