### PR TITLE
🧪: stabilize codex-task help test

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -52,6 +53,7 @@ def test_codex_task_help():
         ],
         capture_output=True,
         text=True,
+        env={**os.environ, "COLUMNS": "80"},
     )
     assert result.returncode == 0
     assert "Parse a Codex task page" in result.stdout


### PR DESCRIPTION
## What
- pin terminal width in codex-task help test

## Why
- narrow width truncated `--clipboard` option on CI

## How to Test
- `python -m pre_commit run --files tests/test_basic.py`
- `pytest -q`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6895a2bf651c832fa42104354ed0e85d