### PR TITLE
🧪: stabilize codex-task help test

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -42,18 +42,13 @@ def test_cli_version():
 
 
 def test_codex_task_help():
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "f2clipboard.cli",
-            "codex-task",
-            "--help",
-        ],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0
+    from typer.testing import CliRunner
+
+    from f2clipboard import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["codex-task", "--help"])
+    assert result.exit_code == 0
     assert "Parse a Codex task page" in result.stdout
     assert "--clipboard" in result.stdout
     assert "--no-clipboard" in result.stdout


### PR DESCRIPTION
## What
- invoke codex-task help test via Typer's CliRunner to avoid terminal-dependent formatting

## Why
- subprocess with forced column width produced blank help output on CI

## How to Test
- pre-commit run --files tests/test_basic.py
- pytest -q

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6895a2bf651c832fa42104354ed0e85d