### PR TITLE
🧪: stabilize codex-task help test

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,8 +1,12 @@
 import subprocess
 import sys
 
-from f2clipboard import __version__
+from typer.testing import CliRunner
+
+from f2clipboard import __version__, app
 from f2clipboard.config import Settings
+
+runner = CliRunner()
 
 
 def test_version_string():
@@ -42,18 +46,8 @@ def test_cli_version():
 
 
 def test_codex_task_help():
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "f2clipboard.cli",
-            "codex-task",
-            "--help",
-        ],
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0
+    result = runner.invoke(app, ["codex-task", "--help"])
+    assert result.exit_code == 0
     assert "Parse a Codex task page" in result.stdout
     assert "--clipboard" in result.stdout
     assert "--no-clipboard" in result.stdout


### PR DESCRIPTION
## What
- use Typer's CliRunner in codex task help test

## Why
- subprocess version depended on terminal width and broke in CI

## How to Test
- `python -m pre_commit run --files tests/test_basic.py`
- `pytest -q`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6895a2bf651c832fa42104354ed0e85d