### PR TITLE
test: stabilize codex-task help output

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,12 +1,9 @@
+import os
 import subprocess
 import sys
 
-from typer.testing import CliRunner
-
-from f2clipboard import __version__, app
+from f2clipboard import __version__
 from f2clipboard.config import Settings
-
-runner = CliRunner()
 
 
 def test_version_string():
@@ -46,12 +43,20 @@ def test_cli_version():
 
 
 def test_codex_task_help():
-    result = runner.invoke(
-        app,
-        ["codex-task", "--help"],
-        env={"COLUMNS": "80", "NO_COLOR": "1"},
+    env = dict(os.environ, COLUMNS="80", NO_COLOR="1")
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "f2clipboard.cli",
+            "codex-task",
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
     )
-    assert result.exit_code == 0
+    assert result.returncode == 0
     stdout = result.stdout
     assert "Parse a Codex task page" in stdout
     assert "--clipboard" in stdout


### PR DESCRIPTION
## Summary
- run codex-task help test via subprocess to ensure stable option output

## Testing
- `pre-commit run --files tests/test_basic.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895a9497340832fa98ed8c1847880e7