### PR TITLE
🧪: stabilize codex-task help test

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -49,7 +49,8 @@ def test_codex_task_help():
     result = runner.invoke(
         app,
         ["codex-task", "--help"],
-        env={"COLUMNS": "80", "NO_COLOR": "1"},
+        env={"COLUMNS": "120"},
+        color=False,
     )
     assert result.exit_code == 0
     stdout = result.stdout


### PR DESCRIPTION
## Summary
- ensure codex-task help test runs without color codes for consistent flag detection

## Testing
- `pre-commit run --files tests/test_basic.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895a9497340832fa98ed8c1847880e7