### PR TITLE
🧪: strip ANSI from codex-task help test

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 
+from click.utils import strip_ansi
 from typer.testing import CliRunner
 
 from f2clipboard import __version__, app
@@ -52,7 +53,7 @@ def test_codex_task_help():
         env={"COLUMNS": "80", "NO_COLOR": "1"},
     )
     assert result.exit_code == 0
-    stdout = result.stdout
+    stdout = strip_ansi(result.stdout)
     assert "Parse a Codex task page" in stdout
     assert "--clipboard" in stdout
     assert "--no-clipboard" in stdout


### PR DESCRIPTION
what: remove ANSI codes before asserting CLI help options
why: rich may inject color sequences causing intermittent failures
how to test: pre-commit run --files tests/test_basic.py && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6895a9497340832fa98ed8c1847880e7