### PR TITLE
🧪 : strip ANSI codes from codex-task help test

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 import sys
 
@@ -5,6 +6,14 @@ from typer.testing import CliRunner
 
 from f2clipboard import __version__, app
 from f2clipboard.config import Settings
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(text: str) -> str:
+    """Return *text* with ANSI escape sequences removed."""
+    return ANSI_RE.sub("", text)
+
 
 runner = CliRunner()
 
@@ -52,7 +61,7 @@ def test_codex_task_help():
         env={"COLUMNS": "80", "NO_COLOR": "1"},
     )
     assert result.exit_code == 0
-    stdout = result.stdout
+    stdout = strip_ansi(result.stdout)
     assert "Parse a Codex task page" in stdout
     assert "--clipboard" in stdout
     assert "--no-clipboard" in stdout


### PR DESCRIPTION
what: remove ANSI escape sequences before asserting CLI help
why: forced color envs split option names and broke tests
how to test: pre-commit run --files tests/test_basic.py && pytest -q
Refs: #58

------
https://chatgpt.com/codex/tasks/task_e_6895a9497340832fa98ed8c1847880e7