### PR TITLE
🐛 : normalise Codex PR links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Parse the Codex task page (authenticated session or scraped HTML via Playwright)
 
 Locate the linked GitHub PR (“View PR” button).
 
+Normalise the PR link by dropping any query parameters or fragments before
+calling the GitHub API.
+
 Query the GitHub API for the check-suite:
 
 For every failed check → download full raw logs.

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -65,7 +65,10 @@ def _extract_pr_url(html: str) -> str | None:
     attribute values, so the regular expression accounts for both variants.
     """
 
-    match = re.search(r"href=['\"](https://github.com/[^'\"]+/pull/\d+)['\"]", html)
+    match = re.search(
+        r"href=['\"](https://github.com/[^'\"?#]+/pull/\d+)(?:[?#][^'\"]*)?['\"]",
+        html,
+    )
     return match.group(1) if match else None
 
 

--- a/tests/test_pr_url_extraction.py
+++ b/tests/test_pr_url_extraction.py
@@ -8,6 +8,8 @@ from f2clipboard.codex_task import _extract_pr_url
     [
         '<a href="https://github.com/owner/repo/pull/123">View PR</a>',
         "<a href='https://github.com/owner/repo/pull/123'>View PR</a>",
+        '<a href="https://github.com/owner/repo/pull/123?utm_source=codex">PR</a>',
+        "<a href='https://github.com/owner/repo/pull/123#discussion'>PR</a>",
     ],
 )
 def test_extract_pr_url_success(html: str) -> None:


### PR DESCRIPTION
## Summary
- strip query params/fragments from Codex PR links
- test PR URL extractor with tracking data
- document PR link normalisation

## Testing
- `pre-commit run --files f2clipboard/codex_task.py tests/test_pr_url_extraction.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896cd9f58a4832f9307cb1313aa65c6