### PR TITLE
🛡️ : redact Bearer tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ f2clipboard files --dir path/to/project
 - [x] Playwright headless login for private Codex tasks. 💯
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
 - [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`github_pat_`, OpenAI
-  `sk-`, and Slack `xoxb-` keys) while preserving whitespace around `=` and `:`. 💯
+  `sk-`, Slack `xoxb-`, and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯

--- a/f2clipboard/secret.py
+++ b/f2clipboard/secret.py
@@ -10,6 +10,7 @@ SECRET_PATTERNS: list[Pattern[str]] = [
     re.compile(r"github_pat_[A-Za-z0-9_]{22,}"),
     re.compile(r"sk-[A-Za-z0-9]{32,}"),
     re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+    re.compile(r"(?i)Bearer\s+[A-Za-z0-9._-]{8,}"),
     re.compile(
         r"(?i)(?P<key>[\w-]*(?:api|token|secret|password)[\w-]*)"
         r"(?P<pre>\s*)(?P<sep>[:=])(?P<post>\s*)"
@@ -42,6 +43,8 @@ def redact_secrets(text: str) -> str:
         if token.startswith("xox"):
             prefix = token.split("-", 1)[0]
             return f"{prefix}-REDACTED"
+        if token.lower().startswith("bearer "):
+            return "Bearer ***"
         return "***"
 
     for pattern in SECRET_PATTERNS:

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -32,6 +32,13 @@ def test_redact_preserves_whitespace():
     assert "api_key:\t***" in redacted
 
 
+def test_redact_bearer_token():
+    text = "Authorization: Bearer abcdef1234567890"  # pragma: allowlist secret
+    redacted = redact_secrets(text)
+    assert "Bearer ***" in redacted
+    assert "abcdef1234567890" not in redacted  # pragma: allowlist secret
+
+
 def test_process_task_redacts(monkeypatch):
     async def fake_html(url: str, cookie: str | None = None) -> str:
         return '<a href="https://github.com/o/r/pull/1">PR</a>'


### PR DESCRIPTION
what: mask Authorization bearer tokens in logs.
why: prevent leaking auth headers.
how to test:
- pre-commit run --files f2clipboard/secret.py tests/test_secret.py
  README.md
- pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6896cd9f58a4832f9307cb1313aa65c6