### PR TITLE
✨: preserve chat line breaks in chat2prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ changes it mentions:
 f2clipboard chat2prompt https://chatgpt.com/share/abcdefg
 ```
 
+HTML tags are stripped and block-level elements become newlines to preserve chat formatting.
+
 Specify a different platform with ``--platform``:
 
 ```bash

--- a/f2clipboard/chat2prompt.py
+++ b/f2clipboard/chat2prompt.py
@@ -11,9 +11,14 @@ import typer
 
 
 def _extract_text(html_text: str) -> str:
-    """Return plain text from HTML."""
+    """Return plain text from HTML, preserving line breaks."""
+    html_text = re.sub(
+        r"</?(?:br|p|div|li|h[1-6])[^>]*>", "\n", html_text, flags=re.IGNORECASE
+    )
     text = re.sub(r"<[^>]+>", "", html_text)
-    return html.unescape(text).strip()
+    text = html.unescape(text)
+    lines = [line.strip() for line in text.splitlines()]
+    return "\n".join(filter(None, lines))
 
 
 def _fetch_transcript(url: str) -> str:

--- a/tests/test_chat2prompt.py
+++ b/tests/test_chat2prompt.py
@@ -13,6 +13,11 @@ def test_extract_text_unescapes_entities():
     assert _extract_text(html) == "Tom & Jerry"
 
 
+def test_extract_text_preserves_line_breaks():
+    html = "<p>Hello</p><p>World</p>"
+    assert _extract_text(html) == "Hello\nWorld"
+
+
 def test_chat2prompt_command_copies_prompt(monkeypatch, capsys):
     def fake_fetch(url: str) -> str:
         assert url == "http://chat"


### PR DESCRIPTION
## What
- retain chat transcript line breaks in `_extract_text`
- document HTML newline handling

## Why
- block elements were collapsing, flattening chat transcripts

## How to Test
- `pre-commit run --files README.md f2clipboard/chat2prompt.py tests/test_chat2prompt.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896cd9f58a4832f9307cb1313aa65c6