### PR TITLE
✨ : list available plugins via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ f2clipboard files --dir path/to/project
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯
 - [x] First plugin: Jira ticket summariser. 💯
 - [x] VS Code task provider / GitHub Action marketplace listing. 💯
+- [x] CLI command to list registered plugins. 💯
 
 ## Getting Started
 
@@ -142,6 +143,12 @@ exposes a callable that receives the Typer app and can register additional comma
 ```toml
 [project.entry-points."f2clipboard.plugins"]
 hello = "my_package.plugin:register"
+```
+
+List installed plugins:
+
+```bash
+f2clipboard plugins
 ```
 
 The first bundled plugin summarises Jira issues:

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -18,6 +18,18 @@ app.command("codex-task")(codex_task_command)
 app.command("chat2prompt")(chat2prompt_command)
 app.command("files")(files_command)
 
+_loaded_plugins: list[str] = []
+
+
+@app.command("plugins")
+def plugins_command() -> None:
+    """List registered plugin names."""
+    if not _loaded_plugins:
+        typer.echo("No plugins installed")
+        return
+    for name in _loaded_plugins:
+        typer.echo(name)
+
 
 def _version_callback(value: bool) -> None:
     """Print the package version and exit."""
@@ -46,6 +58,8 @@ def _load_plugins() -> None:
         try:
             plugin = ep.load()
             plugin(app)
+            if ep.name not in _loaded_plugins:
+                _loaded_plugins.append(ep.name)
         except Exception as exc:  # pragma: no cover - defensive
             logging.getLogger(__name__).warning(
                 "Failed to load plugin %s: %s", ep.name, exc

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -3,6 +3,8 @@
 import importlib
 from importlib.metadata import EntryPoint
 
+from typer.testing import CliRunner
+
 import f2clipboard
 
 
@@ -30,3 +32,23 @@ def test_plugin_loaded(monkeypatch):
     f2clipboard._load_plugins()
     names = [cmd.name for cmd in f2clipboard.app.registered_commands]
     assert "hello" in names
+
+
+def test_plugins_command_lists_plugins(monkeypatch):
+    ep = EntryPoint(
+        name="sample", value="tests.test_plugins:plugin", group="f2clipboard.plugins"
+    )
+
+    def fake_entry_points(*args, **kwargs):
+        if kwargs.get("group") == "f2clipboard.plugins":
+            return [ep]
+        return []
+
+    importlib.reload(f2clipboard)
+    monkeypatch.setattr(f2clipboard, "entry_points", fake_entry_points)
+    f2clipboard._loaded_plugins = []
+    f2clipboard._load_plugins()
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins"])
+    assert result.exit_code == 0
+    assert "sample" in result.stdout


### PR DESCRIPTION
what: add `plugins` command listing registered plugin names and document usage.
why: help users discover installed plugins.
how to test:
- pre-commit run --files f2clipboard/__init__.py tests/test_plugins.py README.md
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_6896cda8aeb8832f8e302d374bef3b3a