### PR TITLE
✨: add --exclude option to files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ f2clipboard files --dir path/to/project
 - [x] First plugin: Jira ticket summariser. 💯
 - [x] VS Code task provider / GitHub Action marketplace listing. 💯
 
+### M4 (quality of life)
+- [x] Support excluding file patterns in `files` command via `--exclude`. 💯
+
 ## Getting Started
 
 ```bash
@@ -114,6 +117,12 @@ Copy selected files from a local repository:
 
 ```bash
 f2clipboard files --dir path/to/project
+```
+
+Exclude glob patterns by repeating `--exclude`:
+
+```bash
+f2clipboard files --dir path/to/project --exclude 'node_modules/*' --exclude '*.log'
 ```
 
 Check the installed version:

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -237,6 +237,12 @@ def build_parser():
     parser.add_argument(
         "--pattern", default="*", help="File glob pattern to match (e.g. *.py or *.py)"
     )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        help="Additional glob patterns to ignore (may be repeated)",
+    )
     return parser
 
 
@@ -246,6 +252,8 @@ def main(argv=None):
     directory = args.dir
     pattern = args.pattern
     ignore_patterns = parse_gitignore()
+    if args.exclude:
+        ignore_patterns.extend(args.exclude)
     files = list_files(directory, pattern, ignore_patterns)
     selected_files = select_files(files)
 

--- a/f2clipboard/files.py
+++ b/f2clipboard/files.py
@@ -13,6 +13,11 @@ def files_command(
     pattern: str = typer.Option(
         "*", "--pattern", help="File glob pattern to match (e.g. *.py)"
     ),
+    exclude: list[str] = typer.Option(
+        [],
+        "--exclude",
+        help="Additional glob patterns to ignore (can be used multiple times)",
+    ),
 ) -> None:
     """Invoke the legacy script to copy selected files to the clipboard."""
     script_path = Path(__file__).resolve().parent.parent / "f2clipboard.py"
@@ -27,4 +32,7 @@ def files_command(
 
     module = module_from_spec(spec)
     spec.loader.exec_module(module)
-    module.main(["--dir", directory, "--pattern", pattern])
+    argv = ["--dir", directory, "--pattern", pattern]
+    for pat in exclude:
+        argv.extend(["--exclude", pat])
+    module.main(argv)

--- a/tests/test_files_exclude.py
+++ b/tests/test_files_exclude.py
@@ -1,0 +1,95 @@
+import importlib.util
+import types
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from f2clipboard import app
+from f2clipboard import files as files_module
+
+
+def _load_legacy_module():
+    spec = importlib.util.spec_from_file_location(
+        "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_list_files_respects_exclude(tmp_path):
+    (tmp_path / "a.py").write_text("a")
+    (tmp_path / "b.py").write_text("b")
+    legacy = _load_legacy_module()
+    files = list(
+        legacy.list_files(str(tmp_path), pattern="*.py", ignore_patterns=["b.py"])
+    )
+    assert str(tmp_path / "a.py") in files
+    assert str(tmp_path / "b.py") not in files
+
+
+def test_files_command_forwards_exclude(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_main(argv):
+        called["argv"] = argv
+
+    class FakeLoader:
+        def exec_module(self, module):
+            module.main = fake_main
+
+    class FakeSpec:
+        loader = FakeLoader()
+
+    monkeypatch.setattr(
+        files_module, "spec_from_file_location", lambda name, path: FakeSpec()
+    )
+    monkeypatch.setattr(
+        files_module, "module_from_spec", lambda spec: types.SimpleNamespace()
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "files",
+            "--dir",
+            str(tmp_path),
+            "--pattern",
+            "*.py",
+            "--exclude",
+            "x",
+            "--exclude",
+            "y",
+        ],
+    )
+    assert result.exit_code == 0
+    assert called["argv"] == [
+        "--dir",
+        str(tmp_path),
+        "--pattern",
+        "*.py",
+        "--exclude",
+        "x",
+        "--exclude",
+        "y",
+    ]
+
+
+def test_legacy_main_uses_exclude(monkeypatch, tmp_path):
+    (tmp_path / "a.py").write_text("a")
+    (tmp_path / "b.py").write_text("b")
+    legacy = _load_legacy_module()
+
+    monkeypatch.setattr(legacy, "select_files", lambda files: list(files))
+
+    copied: dict[str, str] = {}
+    monkeypatch.setattr(
+        legacy.clipboard, "copy", lambda content: copied.setdefault("data", content)
+    )
+
+    legacy.main(["--dir", str(tmp_path), "--pattern", "*.py", "--exclude", "b.py"])
+
+    assert "b.py" not in copied["data"]
+    assert "a.py" in copied["data"]


### PR DESCRIPTION
what: allow ignoring glob patterns when copying files
why: avoid copying unwanted paths
how: pre-commit run --files README.md f2clipboard/files.py f2clipboard.py tests/test_files_exclude.py && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_6896cda8aeb8832f8e302d374bef3b3a