### PR TITLE
🔒 Redact AWS access keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ f2clipboard files --dir path/to/project
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
 - [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`github_pat_`, OpenAI
   `sk-`, and Slack `xoxb-` keys) while preserving whitespace around `=` and `:`. 💯
+- [x] AWS access key redaction. 💯
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯

--- a/f2clipboard/secret.py
+++ b/f2clipboard/secret.py
@@ -10,6 +10,7 @@ SECRET_PATTERNS: list[Pattern[str]] = [
     re.compile(r"github_pat_[A-Za-z0-9_]{22,}"),
     re.compile(r"sk-[A-Za-z0-9]{32,}"),
     re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+    re.compile(r"(?:ASIA|AKIA)[0-9A-Z]{16}"),
     re.compile(
         r"(?i)(?P<key>[\w-]*(?:api|token|secret|password)[\w-]*)"
         r"(?P<pre>\s*)(?P<sep>[:=])(?P<post>\s*)"
@@ -42,6 +43,8 @@ def redact_secrets(text: str) -> str:
         if token.startswith("xox"):
             prefix = token.split("-", 1)[0]
             return f"{prefix}-REDACTED"
+        if token.startswith("AKIA") or token.startswith("ASIA"):
+            return f"{token[:4]}_REDACTED"
         return "***"
 
     for pattern in SECRET_PATTERNS:

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -25,6 +25,13 @@ def test_redact_github_pat():
     assert "github_pat_REDACTED" in redacted
 
 
+def test_redact_aws_access_key():
+    key = "AKIA" + "A" * 16  # pragma: allowlist secret
+    redacted = redact_secrets(f"creds: {key}")
+    assert key not in redacted  # pragma: allowlist secret
+    assert "AKIA_REDACTED" in redacted
+
+
 def test_redact_preserves_whitespace():
     text = "TOKEN = abcdef123456\napi_key:\tsecret1234"  # pragma: allowlist secret
     redacted = redact_secrets(text)


### PR DESCRIPTION
## Summary
- redact AWS access keys
- test secret masking for AKIA tokens
- document AWS key redaction in roadmap

## Testing
- `pre-commit run --files README.md f2clipboard/secret.py tests/test_secret.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896cda8aeb8832f8e302d374bef3b3a