### PR TITLE
🔒 broaden GitHub secret patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ f2clipboard files --dir path/to/project
 ### M2 (hardening)
 - [x] Playwright headless login for private Codex tasks. 💯
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
-- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`github_pat_`, OpenAI
+- [x] Secret scanning & redaction (via custom regex; GitHub
+  `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_`, OpenAI `sk-`, Slack `xoxb-`,
+  and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
 - [x] AWS access key redaction. 💯
-- [x] `sk-`, Slack `xoxb-`, and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import pytest
+
 from f2clipboard.codex_task import _process_task
 from f2clipboard.config import Settings
 from f2clipboard.secret import redact_secrets
@@ -23,6 +25,14 @@ def test_redact_github_pat():
     redacted = redact_secrets(token)
     assert "c" * 10 not in redacted  # pragma: allowlist secret
     assert "github_pat_REDACTED" in redacted
+
+
+@pytest.mark.parametrize("prefix", ["gho_", "ghu_", "ghs_", "ghr_"])
+def test_redact_other_github_tokens(prefix):
+    token = prefix + "d" * 36  # pragma: allowlist secret
+    redacted = redact_secrets(token)
+    assert token not in redacted  # pragma: allowlist secret
+    assert f"{prefix[:3]}_REDACTED" in redacted
 
 
 def test_redact_aws_access_key():


### PR DESCRIPTION
## Summary
- extend secret scanner to cover gho_/ghu_/ghs_/ghr_ tokens
- document roadmap completion

## Testing
- `pre-commit run --files f2clipboard/secret.py tests/test_secret.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ebf14100832fbbdf42f370292cdb