### PR TITLE
🔒 : broaden OpenAI key redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For every successful check → ignore.
 If a log exceeds 150 kB → invoke an LLM (configurable, OpenAI or Anthropic) to summarise the failure.
 
 Secrets such as API tokens are redacted from logs before summarisation or output.
+Patterns handle GitHub and OpenAI keys, Slack tokens, and generic bearer secrets.
 
 Emit a Markdown snippet ready for pasting back into Codex:
 
@@ -57,9 +58,9 @@ f2clipboard files --dir path/to/project
 ### M2 (hardening)
 - [x] Playwright headless login for private Codex tasks. 💯
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
-- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`github_pat_`, OpenAI
+- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`github_pat_`, OpenAI `sk-`,
+  Slack `xoxb-`, and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
 - [x] AWS access key redaction. 💯
-- [x] `sk-`, Slack `xoxb-`, and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯

--- a/f2clipboard/secret.py
+++ b/f2clipboard/secret.py
@@ -8,7 +8,8 @@ from typing import Pattern
 SECRET_PATTERNS: list[Pattern[str]] = [
     re.compile(r"ghp_[A-Za-z0-9]{36}"),
     re.compile(r"github_pat_[A-Za-z0-9_]{22,}"),
-    re.compile(r"sk-[A-Za-z0-9]{32,}"),
+    # OpenAI API keys now include dashes in some segments (e.g. ``sk-live-``)
+    re.compile(r"sk-[A-Za-z0-9-]{32,}"),
     re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
     re.compile(r"(?:ASIA|AKIA)[0-9A-Z]{16}"),
     re.compile(r"(?i)Bearer\s+[A-Za-z0-9._-]{8,}"),

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -25,6 +25,13 @@ def test_redact_github_pat():
     assert "github_pat_REDACTED" in redacted
 
 
+def test_redact_openai_token_with_hyphen():
+    token = "sk-live-" + "d" * 40  # pragma: allowlist secret
+    redacted = redact_secrets(token)
+    assert "sk-REDACTED" in redacted
+    assert "d" * 10 not in redacted  # pragma: allowlist secret
+
+
 def test_redact_aws_access_key():
     key = "AKIA" + "A" * 16  # pragma: allowlist secret
     redacted = redact_secrets(f"creds: {key}")


### PR DESCRIPTION
## What
- handle hyphenated `sk-` API keys in secret scanner
- document supported secret patterns and mark roadmap

## Why
- new OpenAI keys may expose secrets if not redacted

## How to Test
- `pre-commit run --files README.md f2clipboard/secret.py tests/test_secret.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ebf14100832fbbdf42f370292cdb