### PR TITLE
🛡️ : mark secret redaction roadmap item as complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ f2clipboard files --dir path/to/project
 ### M2 (hardening)
 - [x] Playwright headless login for private Codex tasks. 💯
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
-- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`github_pat_`, OpenAI
+- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`github_pat_`, OpenAI `sk-`, Slack `xoxb-`, and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
 - [x] AWS access key redaction. 💯
-- [x] `sk-`, Slack `xoxb-`, and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -25,6 +25,14 @@ def test_redact_github_pat():
     assert "github_pat_REDACTED" in redacted
 
 
+def test_redact_github_pat_assignment():
+    token = "github_pat_" + "d" * 50  # pragma: allowlist secret
+    text = f"GITHUB_TOKEN={token}"
+    redacted = redact_secrets(text)
+    assert token not in redacted  # pragma: allowlist secret
+    assert "GITHUB_TOKEN=***" in redacted
+
+
 def test_redact_aws_access_key():
     key = "AKIA" + "A" * 16  # pragma: allowlist secret
     redacted = redact_secrets(f"creds: {key}")


### PR DESCRIPTION
## Summary
- mark secret scanning & redaction milestone as complete
- add regression test for github_pat token assignment

## Testing
- `pre-commit run --files README.md tests/test_secret.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ebf14100832fbbdf42f370292cdb