### PR TITLE
🐛: support trailing slash in PR URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Parse the Codex task page (authenticated session or scraped HTML via Playwright)
 
 Locate the linked GitHub PR (“View PR” button).
 
-Normalise the PR link by dropping any query parameters or fragments before
-calling the GitHub API.
+Normalise the PR link by dropping any query parameters, fragments or trailing
+slashes before calling the GitHub API.
 
 Query the GitHub API for the check-suite:
 

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -62,20 +62,24 @@ def _extract_pr_url(html: str) -> str | None:
 
     The Codex task page includes a "View PR" link pointing to the associated
     GitHub pull request. Codex's markup may use single or double quotes around
-    attribute values, so the regular expression accounts for both variants.
+    attribute values and may include a trailing slash, so the regular
+    expression accounts for these variants.
     """
 
     match = re.search(
-        r"href=['\"](https://github.com/[^'\"?#]+/pull/\d+)(?:[?#][^'\"]*)?['\"]",
+        r"href=['\"](https://github.com/[^'\"?#]+/pull/\d+)(?:/)?(?:[?#][^'\"]*)?['\"]",
         html,
     )
     return match.group(1) if match else None
 
 
 def _parse_pr_url(pr_url: str) -> tuple[str, str, int]:
-    """Extract owner, repo and pull number from a PR URL."""
+    """Extract owner, repo and pull number from a PR URL.
+
+    Trailing slashes are tolerated and ignored.
+    """
     pattern = (
-        r"https://github.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)"
+        r"https://github.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)/?"
     )
     match = re.match(pattern, pr_url)
     if not match:  # pragma: no cover - defensive programming

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -33,6 +33,14 @@ def test_parse_pr_url():
     )
 
 
+def test_parse_pr_url_trailing_slash() -> None:
+    assert _parse_pr_url("https://github.com/owner/repo/pull/42/") == (
+        "owner",
+        "repo",
+        42,
+    )
+
+
 def test_fetch_check_runs_parses_response(monkeypatch):
     class DummyResponse:
         def __init__(self, data):

--- a/tests/test_pr_url_extraction.py
+++ b/tests/test_pr_url_extraction.py
@@ -10,6 +10,7 @@ from f2clipboard.codex_task import _extract_pr_url
         "<a href='https://github.com/owner/repo/pull/123'>View PR</a>",
         '<a href="https://github.com/owner/repo/pull/123?utm_source=codex">PR</a>',
         "<a href='https://github.com/owner/repo/pull/123#discussion'>PR</a>",
+        '<a href="https://github.com/owner/repo/pull/123/">PR</a>',
     ],
 )
 def test_extract_pr_url_success(html: str) -> None:


### PR DESCRIPTION
what: handle PR URLs that end with a slash
why: tolerate common link formatting
how to test: python -m pre_commit run --files f2clipboard/codex_task.py tests/test_pr_url_extraction.py tests/test_codex_task.py README.md && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_6896ebbccc7c832fb73bc77421d41a8c