### PR TITLE
🔐 : broaden Slack token redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ f2clipboard files --dir path/to/project
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
 - [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`github_pat_`, OpenAI
 - [x] AWS access key redaction. 💯
-- [x] `sk-`, Slack `xoxb-`, and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
+- [x] `sk-`, Slack `xox*`, and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯

--- a/f2clipboard/secret.py
+++ b/f2clipboard/secret.py
@@ -9,7 +9,7 @@ SECRET_PATTERNS: list[Pattern[str]] = [
     re.compile(r"ghp_[A-Za-z0-9]{36}"),
     re.compile(r"github_pat_[A-Za-z0-9_]{22,}"),
     re.compile(r"sk-[A-Za-z0-9]{32,}"),
-    re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+    re.compile(r"xox[a-zA-Z]-[A-Za-z0-9-]{10,}"),
     re.compile(r"(?:ASIA|AKIA)[0-9A-Z]{16}"),
     re.compile(r"(?i)Bearer\s+[A-Za-z0-9._-]{8,}"),
     re.compile(

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -46,6 +46,13 @@ def test_redact_bearer_token():
     assert "abcdef1234567890" not in redacted  # pragma: allowlist secret
 
 
+def test_redact_other_slack_tokens():
+    token = "xoxe-" + "d" * 40  # pragma: allowlist secret
+    redacted = redact_secrets(token)
+    assert token not in redacted  # pragma: allowlist secret
+    assert "xoxe-REDACTED" in redacted
+
+
 def test_process_task_redacts(monkeypatch):
     async def fake_html(url: str, cookie: str | None = None) -> str:
         return '<a href="https://github.com/o/r/pull/1">PR</a>'


### PR DESCRIPTION
## Summary
- expand Slack token regex to match any `xox*` prefix
- test and document additional Slack token redaction

## Testing
- `pre-commit run --files f2clipboard/secret.py tests/test_secret.py README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896ebbccc7c832fb73bc77421d41a8c