### PR TITLE
✨ : trim whitespace in brace patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ Exclude glob patterns by repeating `--exclude`:
 f2clipboard files --dir path/to/project --exclude 'node_modules/*' --exclude '*.log'
 ```
 
+Use brace expansion in patterns to match multiple extensions:
+
+```bash
+f2clipboard files --pattern '*.{py,js}'
+```
+
 Check the installed version:
 
 ```bash

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -80,7 +80,10 @@ def expand_pattern(pattern):
 
     prefix = pattern[: pattern.find("{")]
     suffix = pattern[pattern.find("}") + 1 :]
-    options = pattern[pattern.find("{") + 1 : pattern.find("}")].split(",")
+    options = [
+        opt.strip()
+        for opt in pattern[pattern.find("{") + 1 : pattern.find("}")].split(",")
+    ]
     return [f"{prefix}{opt}{suffix}" for opt in options]
 
 

--- a/tests/test_expand_pattern.py
+++ b/tests/test_expand_pattern.py
@@ -1,0 +1,16 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+spec = spec_from_file_location(
+    "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+)
+module = module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def test_expand_pattern_strips_whitespace():
+    assert module.expand_pattern("*.{py, js}") == ["*.py", "*.js"]
+
+
+def test_expand_pattern_no_braces():
+    assert module.expand_pattern("*.py") == ["*.py"]


### PR DESCRIPTION
what: strip spaces from brace-expanded options in legacy file workflow
why: patterns like '*.{py, js}' now match both extensions
how to test: pre-commit run --files f2clipboard.py README.md tests/test_expand_pattern.py && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_6896ebbccc7c832fb73bc77421d41a8c