### PR TITLE
feat: redact Slack app tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,8 @@ f2clipboard files --dir path/to/project
 ### M2 (hardening)
 - [x] Playwright headless login for private Codex tasks. 💯
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
-- [x] Secret scanning & redaction (via custom regex; GitHub
-  `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_`, OpenAI `sk-`, Slack `xoxb-`,
-  and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
+- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_`, OpenAI `sk-`, Slack `xoxb-` and `xapp-`, and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
 - [x] AWS access key redaction. 💯
-- [x] `sk-`, Slack `xox*`, and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
 
 ### M3 (extensibility)
 - [x] Plugin interface (`entry_points = "f2clipboard.plugins"`). 💯

--- a/f2clipboard/secret.py
+++ b/f2clipboard/secret.py
@@ -12,7 +12,7 @@ SECRET_PATTERNS: list[Pattern[str]] = [
     re.compile(r"github_pat_[A-Za-z0-9_]{22,}"),
     # OpenAI, Slack, AWS and Bearer tokens
     re.compile(r"sk-[A-Za-z0-9]{32,}"),
-    re.compile(r"xox[a-zA-Z]-[A-Za-z0-9-]{10,}"),
+    re.compile(r"(?:xox[a-zA-Z]|xapp)-[A-Za-z0-9-]{10,}"),
     re.compile(r"(?:ASIA|AKIA)[0-9A-Z]{16}"),
     re.compile(r"(?i)Bearer\s+[A-Za-z0-9._-]{8,}"),
     re.compile(
@@ -48,7 +48,7 @@ def redact_secrets(text: str) -> str:
             return "github_pat_REDACTED"
         if token.startswith("sk-"):
             return "sk-REDACTED"
-        if token.startswith("xox"):
+        if token.startswith("xox") or token.startswith("xapp"):
             prefix = token.split("-", 1)[0]
             return f"{prefix}-REDACTED"
         if token.startswith("AKIA") or token.startswith("ASIA"):

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -63,6 +63,13 @@ def test_redact_other_slack_tokens():
     assert "xoxe-REDACTED" in redacted
 
 
+def test_redact_slack_app_token():
+    token = "xapp-" + "e" * 40  # pragma: allowlist secret
+    redacted = redact_secrets(token)
+    assert token not in redacted  # pragma: allowlist secret
+    assert "xapp-REDACTED" in redacted
+
+
 def test_process_task_redacts(monkeypatch):
     async def fake_html(url: str, cookie: str | None = None) -> str:
         return '<a href="https://github.com/o/r/pull/1">PR</a>'


### PR DESCRIPTION
## Summary
- redact Slack app (`xapp-`) tokens
- document secret scanning for Slack app tokens

## Testing
- `pre-commit run --files f2clipboard/secret.py tests/test_secret.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689918491b30832f8df043ad4d9aabdc