### PR TITLE
🐛: handle whitespace and case in PR URL detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Parse the Codex task page (authenticated session or scraped HTML via Playwright)
 
 Locate the linked GitHub PR (“View PR” button).
 
-Normalise the PR link by dropping any query parameters, fragments or trailing
-slashes before calling the GitHub API.
+Normalise the PR link—tolerating attribute whitespace and casing—by dropping
+any query parameters, fragments or trailing slashes before calling the GitHub
+API.
 
 Query the GitHub API for the check-suite:
 

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -62,13 +62,15 @@ def _extract_pr_url(html: str) -> str | None:
 
     The Codex task page includes a "View PR" link pointing to the associated
     GitHub pull request. Codex's markup may use single or double quotes around
-    attribute values and may include a trailing slash, so the regular
-    expression accounts for these variants.
+    attribute values, whitespace around the equals sign and different attribute
+    casing. The regular expression accounts for these variants, ignoring case
+    and normalising the extracted URL.
     """
 
     match = re.search(
-        r"href=['\"](https://github.com/[^'\"?#]+/pull/\d+)(?:/)?(?:[?#][^'\"]*)?['\"]",
+        r"href\s*=\s*['\"](https://github.com/[^'\"?#]+/pull/\d+)(?:/)?(?:[?#][^'\"]*)?['\"]",
         html,
+        flags=re.IGNORECASE,
     )
     return match.group(1) if match else None
 

--- a/tests/test_pr_url_extraction.py
+++ b/tests/test_pr_url_extraction.py
@@ -11,6 +11,8 @@ from f2clipboard.codex_task import _extract_pr_url
         '<a href="https://github.com/owner/repo/pull/123?utm_source=codex">PR</a>',
         "<a href='https://github.com/owner/repo/pull/123#discussion'>PR</a>",
         '<a href="https://github.com/owner/repo/pull/123/">PR</a>',
+        '<a href = "https://github.com/owner/repo/pull/123">PR</a>',
+        '<a HREF="https://github.com/owner/repo/pull/123">PR</a>',
     ],
 )
 def test_extract_pr_url_success(html: str) -> None:


### PR DESCRIPTION
## Summary
- make PR link extraction tolerant of attribute whitespace and casing
- document improved PR normalization

## Testing
- `pre-commit run --files f2clipboard/codex_task.py tests/test_pr_url_extraction.py README.md`
- `pytest -q`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689abb294504832fa2e845af843092d1