### PR TITLE
✨ add timeout option to chat2prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ Specify a different platform with ``--platform``:
 f2clipboard chat2prompt https://chatgpt.com/share/abcdefg --platform anthropic
 ```
 
+Adjust the HTTP timeout (default 10 seconds):
+
+```bash
+f2clipboard chat2prompt https://chatgpt.com/share/abcdefg --timeout 5
+```
+
 Copy selected files from a local repository:
 
 ```bash

--- a/f2clipboard/chat2prompt.py
+++ b/f2clipboard/chat2prompt.py
@@ -21,9 +21,9 @@ def _extract_text(html_text: str) -> str:
     return "\n".join(filter(None, lines))
 
 
-def _fetch_transcript(url: str) -> str:
+def _fetch_transcript(url: str, timeout: float = 10.0) -> str:
     """Download transcript text from a shared chat URL."""
-    response = httpx.get(url, follow_redirects=True)
+    response = httpx.get(url, follow_redirects=True, timeout=timeout)
     response.raise_for_status()
     return _extract_text(response.text)
 
@@ -43,9 +43,12 @@ def chat2prompt_command(
     copy_to_clipboard: bool = typer.Option(
         True, "--clipboard/--no-clipboard", help="Copy prompt to clipboard."
     ),
+    timeout: float = typer.Option(
+        10.0, "--timeout", help="HTTP request timeout in seconds"
+    ),
 ) -> None:
     """Create a coding prompt from a chat transcript and copy it to the clipboard."""
-    transcript = _fetch_transcript(url)
+    transcript = _fetch_transcript(url, timeout=timeout)
     prompt = _build_prompt(transcript, platform)
     if copy_to_clipboard:
         clipboard.copy(prompt)

--- a/tests/test_chat2prompt.py
+++ b/tests/test_chat2prompt.py
@@ -1,6 +1,10 @@
 import clipboard
 
-from f2clipboard.chat2prompt import _extract_text, chat2prompt_command
+from f2clipboard.chat2prompt import (
+    _extract_text,
+    _fetch_transcript,
+    chat2prompt_command,
+)
 
 
 def test_extract_text_removes_html():
@@ -19,8 +23,9 @@ def test_extract_text_preserves_line_breaks():
 
 
 def test_chat2prompt_command_copies_prompt(monkeypatch, capsys):
-    def fake_fetch(url: str) -> str:
+    def fake_fetch(url: str, timeout: float) -> str:
         assert url == "http://chat"
+        assert timeout == 10.0
         return "User: Hi\nAssistant: Hello"
 
     monkeypatch.setattr("f2clipboard.chat2prompt._fetch_transcript", fake_fetch)
@@ -31,8 +36,35 @@ def test_chat2prompt_command_copies_prompt(monkeypatch, capsys):
         copied["text"] = text
 
     monkeypatch.setattr(clipboard, "copy", fake_copy)
-    chat2prompt_command("http://chat", platform="anthropic")
+    chat2prompt_command("http://chat", platform="anthropic", timeout=10.0)
     out = capsys.readouterr().out
     assert "anthropic" in out
     assert "User: Hi" in copied["text"]
     assert "implement" in copied["text"]
+
+
+def test_fetch_transcript_uses_timeout(monkeypatch):
+    called: dict[str, float | None] = {}
+
+    class DummyResponse:
+        text = ""
+
+        def raise_for_status(self) -> None:  # pragma: no cover - no errors
+            return
+
+    def fake_get(url: str, *, follow_redirects: bool, timeout: float | None):
+        called["timeout"] = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr("httpx.get", fake_get)
+    _fetch_transcript("http://chat", timeout=5)
+    assert called["timeout"] == 5
+
+
+def test_chat2prompt_command_respects_timeout(monkeypatch):
+    def fake_fetch(url: str, timeout: float) -> str:
+        assert timeout == 2
+        return ""
+
+    monkeypatch.setattr("f2clipboard.chat2prompt._fetch_transcript", fake_fetch)
+    chat2prompt_command("http://chat", timeout=2, copy_to_clipboard=False)


### PR DESCRIPTION
## Summary
- allow chat2prompt to set an HTTP timeout via `--timeout`
- document timeout flag in README
- test chat2prompt's timeout handling

## Testing
- `pre-commit run --files f2clipboard/chat2prompt.py tests/test_chat2prompt.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689abb294504832fa2e845af843092d1