### PR TITLE
🔒 : handle base64 secrets in redaction regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ f2clipboard files --dir path/to/project
 ### M2 (hardening)
 - [x] Playwright headless login for private Codex tasks. 💯
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
-- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_`, OpenAI `sk-`, Slack `xoxb-` and `xapp-`, and `Bearer` tokens) while preserving whitespace around `=` and `:`. 💯
+- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_`, OpenAI `sk-`, Slack `xoxb-` and `xapp-`, `Bearer` tokens, and base64-like secrets containing `+`, `/` or `=`) while preserving whitespace around `=` and `:`. 💯
 - [x] AWS access key redaction. 💯
 
 ### M3 (extensibility)

--- a/f2clipboard/secret.py
+++ b/f2clipboard/secret.py
@@ -18,7 +18,7 @@ SECRET_PATTERNS: list[Pattern[str]] = [
     re.compile(
         r"(?i)(?P<key>[\w-]*(?:api|token|secret|password)[\w-]*)"
         r"(?P<pre>\s*)(?P<sep>[:=])(?P<post>\s*)"
-        r"(?P<value>[A-Za-z0-9-_.]{8,})"
+        r"(?P<value>[A-Za-z0-9-_.+/=]{8,})"
     ),
 ]
 

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -70,6 +70,13 @@ def test_redact_slack_app_token():
     assert "xapp-REDACTED" in redacted
 
 
+def test_redact_env_token_with_special_chars():
+    text = "API_TOKEN=abc/def+ghi=="  # pragma: allowlist secret
+    redacted = redact_secrets(text)
+    assert "abc/def+ghi==" not in redacted  # pragma: allowlist secret
+    assert "API_TOKEN=***" in redacted
+
+
 def test_process_task_redacts(monkeypatch):
     async def fake_html(url: str, cookie: str | None = None) -> str:
         return '<a href="https://github.com/o/r/pull/1">PR</a>'


### PR DESCRIPTION
## What
- expand generic secret matcher to capture `+`, `/`, `=` tokens
- note base64-like secret support in docs

## Why
- env-style secrets containing those chars were not redacted

## How to test
- `pre-commit run --files f2clipboard/secret.py tests/test_secret.py README.md`
- `pytest -q`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689abb294504832fa2e845af843092d1