### PR TITLE
🐛 fix: ignore non-failing check runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ slashes before calling the GitHub API.
 
 Query the GitHub API for the check-suite:
 
-For every failed check → download full raw logs.
+For checks concluding with `failure`, `timed_out`, `cancelled` or `action_required`
+→ download full raw logs.
 
-For every successful check → ignore.
+For checks concluding with `success`, `neutral`, `skipped` or any other
+non-failure state → ignore.
 
 If a log exceeds 150 kB → invoke an LLM (configurable, OpenAI or Anthropic) to summarise the failure.
 
@@ -32,7 +34,7 @@ Secrets such as API tokens are redacted from logs before summarisation or output
 
 Emit a Markdown snippet ready for pasting back into Codex:
 
-Each failed check becomes a fenced code-block labelled with job name & link.
+Each failing check becomes a fenced code-block labelled with job name & link.
 
 Oversized logs are replaced by the summary plus a collapsible <details> section with the first 100 lines for context.
 

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -187,6 +187,31 @@ def test_process_task_small_log_skips_summarise(monkeypatch):
     assert not called
 
 
+def test_process_task_ignores_non_failed_runs(monkeypatch):
+    async def fake_html(url: str, cookie: str | None = None) -> str:
+        return '<a href="https://github.com/o/r/pull/1">PR</a>'
+
+    async def fake_runs(pr_url: str, token: str | None):
+        return [
+            {"id": 1, "name": "Neutral", "conclusion": "neutral"},
+            {"id": 2, "name": "Pending", "conclusion": None},
+            {"id": 3, "name": "Fail", "conclusion": "failure"},
+        ]
+
+    async def fake_log(client, owner, repo, run_id):
+        return f"log {run_id}"
+
+    monkeypatch.setattr("f2clipboard.codex_task._fetch_task_html", fake_html)
+    monkeypatch.setattr("f2clipboard.codex_task._fetch_check_runs", fake_runs)
+    monkeypatch.setattr("f2clipboard.codex_task._download_log", fake_log)
+
+    settings = Settings()
+    result = asyncio.run(_process_task("http://task", settings))
+    assert "log 3" in result
+    assert "log 1" not in result
+    assert "log 2" not in result
+
+
 def test_codex_task_command_copies_to_clipboard(monkeypatch, capsys):
     async def fake_process(url: str, settings: Settings) -> str:
         return "MD"


### PR DESCRIPTION
## Summary
- skip GitHub check runs that end in success, neutral, or skipped
- document which conclusions are processed
- test that only failing runs emit logs

## Testing
- `pre-commit run --files README.md f2clipboard/codex_task.py tests/test_codex_task.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689abb294504832fa2e845af843092d1