### PR TITLE
✨: add dry-run option to files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ f2clipboard files --dir path/to/project
 
 ### M4 (quality of life)
 - [x] Support excluding file patterns in `files` command via `--exclude`. 💯
+- [x] Dry-run option for `files` command to print Markdown instead of copying. 💯
 
 ## Getting Started
 
@@ -129,6 +130,12 @@ Exclude glob patterns by repeating `--exclude`:
 
 ```bash
 f2clipboard files --dir path/to/project --exclude 'node_modules/*' --exclude '*.log'
+```
+
+Preview output without copying to the clipboard:
+
+```bash
+f2clipboard files --dir path/to/project --dry-run
 ```
 
 Use brace expansion in patterns to match multiple extensions:

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -246,6 +246,11 @@ def build_parser():
         default=[],
         help="Additional glob patterns to ignore (may be repeated)",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print formatted Markdown instead of copying to clipboard",
+    )
     return parser
 
 
@@ -264,10 +269,13 @@ def main(argv=None):
         clipboard_content = format_files_for_clipboard(
             selected_files, directory, ignore_patterns
         )
-        clipboard.copy(clipboard_content)
-        print(
-            "🚀 The formatted files have been copied to your clipboard. Ready to paste!"
-        )
+        if args.dry_run:
+            print(clipboard_content)
+        else:
+            clipboard.copy(clipboard_content)
+            print(
+                "🚀 The formatted files have been copied to your clipboard. Ready to paste!"
+            )
     else:
         print("🚫 No files selected.")
 

--- a/f2clipboard/files.py
+++ b/f2clipboard/files.py
@@ -18,6 +18,9 @@ def files_command(
         "--exclude",
         help="Additional glob patterns to ignore (can be used multiple times)",
     ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print Markdown instead of copying to clipboard"
+    ),
 ) -> None:
     """Invoke the legacy script to copy selected files to the clipboard."""
     script_path = Path(__file__).resolve().parent.parent / "f2clipboard.py"
@@ -35,4 +38,6 @@ def files_command(
     argv = ["--dir", directory, "--pattern", pattern]
     for pat in exclude:
         argv.extend(["--exclude", pat])
+    if dry_run:
+        argv.append("--dry-run")
     module.main(argv)

--- a/tests/test_files_dry_run.py
+++ b/tests/test_files_dry_run.py
@@ -1,0 +1,65 @@
+import importlib.util
+import types
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from f2clipboard import app
+from f2clipboard import files as files_module
+
+
+def _load_legacy_module():
+    spec = importlib.util.spec_from_file_location(
+        "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_files_command_forwards_dry_run(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_main(argv):
+        called["argv"] = argv
+
+    class FakeLoader:
+        def exec_module(self, module):
+            module.main = fake_main
+
+    class FakeSpec:
+        loader = FakeLoader()
+
+    monkeypatch.setattr(
+        files_module, "spec_from_file_location", lambda name, path: FakeSpec()
+    )
+    monkeypatch.setattr(
+        files_module, "module_from_spec", lambda spec: types.SimpleNamespace()
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["files", "--dir", str(tmp_path), "--dry-run"],
+    )
+    assert result.exit_code == 0
+    assert called["argv"] == ["--dir", str(tmp_path), "--pattern", "*", "--dry-run"]
+
+
+def test_legacy_main_dry_run(monkeypatch, tmp_path, capsys):
+    (tmp_path / "a.py").write_text("a")
+    legacy = _load_legacy_module()
+
+    monkeypatch.setattr(legacy, "select_files", lambda files: list(files))
+
+    copied: dict[str, str] = {}
+    monkeypatch.setattr(
+        legacy.clipboard, "copy", lambda content: copied.setdefault("data", content)
+    )
+
+    legacy.main(["--dir", str(tmp_path), "--pattern", "*.py", "--dry-run"])
+
+    out = capsys.readouterr().out
+    assert "a.py" in out
+    assert "data" not in copied


### PR DESCRIPTION
what: add --dry-run flag to files command
why: preview markdown without copying to clipboard
how to test: pre-commit run --files README.md f2clipboard/files.py f2clipboard.py tests/test_files_dry_run.py && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689abb35e8b0832fb87b9b98e8ad1b40