### PR TITLE
Add --no-clipboard option to files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ f2clipboard files --dir path/to/project
 
 ### M4 (quality of life)
 - [x] Support excluding file patterns in `files` command via `--exclude`. 💯
+- [x] Allow skipping clipboard copy in `files` command via `--no-clipboard`. 💯
 
 ## Getting Started
 
@@ -123,6 +124,12 @@ Copy selected files from a local repository:
 
 ```bash
 f2clipboard files --dir path/to/project
+```
+
+To skip copying to the clipboard, pass `--no-clipboard`:
+
+```bash
+f2clipboard files --dir path/to/project --no-clipboard
 ```
 
 Exclude glob patterns by repeating `--exclude`:

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -246,6 +246,11 @@ def build_parser():
         default=[],
         help="Additional glob patterns to ignore (may be repeated)",
     )
+    parser.add_argument(
+        "--no-clipboard",
+        action="store_true",
+        help="Print output instead of copying to the clipboard",
+    )
     return parser
 
 
@@ -264,10 +269,12 @@ def main(argv=None):
         clipboard_content = format_files_for_clipboard(
             selected_files, directory, ignore_patterns
         )
-        clipboard.copy(clipboard_content)
-        print(
-            "🚀 The formatted files have been copied to your clipboard. Ready to paste!"
-        )
+        print(clipboard_content)
+        if not args.no_clipboard:
+            clipboard.copy(clipboard_content)
+            print(
+                "🚀 The formatted files have been copied to your clipboard. Ready to paste!"
+            )
     else:
         print("🚫 No files selected.")
 

--- a/f2clipboard/files.py
+++ b/f2clipboard/files.py
@@ -18,6 +18,11 @@ def files_command(
         "--exclude",
         help="Additional glob patterns to ignore (can be used multiple times)",
     ),
+    copy_to_clipboard: bool = typer.Option(
+        True,
+        "--clipboard/--no-clipboard",
+        help="Copy formatted output to the clipboard",
+    ),
 ) -> None:
     """Invoke the legacy script to copy selected files to the clipboard."""
     script_path = Path(__file__).resolve().parent.parent / "f2clipboard.py"
@@ -35,4 +40,6 @@ def files_command(
     argv = ["--dir", directory, "--pattern", pattern]
     for pat in exclude:
         argv.extend(["--exclude", pat])
+    if not copy_to_clipboard:
+        argv.append("--no-clipboard")
     module.main(argv)

--- a/tests/test_files_no_clipboard.py
+++ b/tests/test_files_no_clipboard.py
@@ -1,0 +1,82 @@
+import importlib.util
+import types
+from pathlib import Path
+
+from click.utils import strip_ansi
+from typer.testing import CliRunner
+
+from f2clipboard import app
+from f2clipboard import files as files_module
+
+runner = CliRunner()
+
+
+def _load_legacy_module():
+    spec = importlib.util.spec_from_file_location(
+        "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_files_help_shows_no_clipboard():
+    result = runner.invoke(
+        app, ["files", "--help"], env={"COLUMNS": "80", "NO_COLOR": "1"}
+    )
+    assert result.exit_code == 0
+    stdout = strip_ansi(result.stdout)
+    assert "--no-clipboard" in stdout
+
+
+def test_files_command_forwards_no_clipboard(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_main(argv):
+        called["argv"] = argv
+
+    class FakeLoader:
+        def exec_module(self, module):
+            module.main = fake_main
+
+    class FakeSpec:
+        loader = FakeLoader()
+
+    monkeypatch.setattr(
+        files_module, "spec_from_file_location", lambda name, path: FakeSpec()
+    )
+    monkeypatch.setattr(
+        files_module, "module_from_spec", lambda spec: types.SimpleNamespace()
+    )
+
+    result = runner.invoke(
+        app,
+        ["files", "--dir", str(tmp_path), "--no-clipboard"],
+    )
+    assert result.exit_code == 0
+    assert called["argv"] == [
+        "--dir",
+        str(tmp_path),
+        "--pattern",
+        "*",
+        "--no-clipboard",
+    ]
+
+
+def test_legacy_main_no_clipboard(monkeypatch, tmp_path, capsys):
+    (tmp_path / "a.py").write_text("a")
+    legacy = _load_legacy_module()
+
+    monkeypatch.setattr(legacy, "select_files", lambda files: list(files))
+
+    copied: dict[str, str] = {}
+    monkeypatch.setattr(
+        legacy.clipboard, "copy", lambda content: copied.setdefault("data", content)
+    )
+
+    legacy.main(["--dir", str(tmp_path), "--pattern", "*.py", "--no-clipboard"])
+
+    captured = capsys.readouterr()
+    assert "a.py" in captured.out
+    assert "data" not in copied


### PR DESCRIPTION
## Summary
- allow files command to print output without copying to clipboard
- document and test the `--no-clipboard` flag

## Testing
- `pre-commit run --files README.md f2clipboard/files.py f2clipboard.py tests/test_files_no_clipboard.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689abb35e8b0832fb87b9b98e8ad1b40