### PR TITLE
✨: allow saving codex-task output

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ f2clipboard files --dir path/to/project
 
 ### M4 (quality of life)
 - [x] Support excluding file patterns in `files` command via `--exclude`. 💯
+- [x] Allow saving `codex-task` output via `--output`. 💯
 
 ## Getting Started
 
@@ -93,6 +94,12 @@ To skip copying to the clipboard, pass ``--no-clipboard``:
 
 ```bash
 f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --no-clipboard
+```
+
+Save the Markdown to a file with ``--output``:
+
+```bash
+f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --output task.md
 ```
 
 Adjust the log size threshold for summarisation with ``--log-size-threshold``:

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import gzip
 import re
+from pathlib import Path
 from typing import Annotated, Any
 
 import clipboard
@@ -178,11 +179,16 @@ def codex_task_command(
             help="Summarise logs larger than this many bytes.",
         ),
     ] = None,
+    output: Annotated[
+        Path | None,
+        typer.Option("--output", help="Write Markdown to a file."),
+    ] = None,
 ) -> None:
     """Parse a Codex task page and print any failing GitHub checks.
 
     The generated Markdown is copied to the clipboard unless ``--no-clipboard`` is passed.
-    Use ``--log-size-threshold`` to override the summarisation threshold.
+    Use ``--log-size-threshold`` to override the summarisation threshold. Pass
+    ``--output`` to save the result to a file.
     """
     typer.echo(f"Parsing Codex task page: {url}…")
     if log_size_threshold is not None:
@@ -190,6 +196,8 @@ def codex_task_command(
     else:
         settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
     result = asyncio.run(_process_task(url, settings))
+    if output is not None:
+        output.write_text(result)
     if copy_to_clipboard:
         clipboard.copy(result)
     typer.echo(result)

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -249,6 +249,17 @@ def test_codex_task_command_initialises_settings_once(monkeypatch):
     assert calls == [5]
 
 
+def test_codex_task_command_writes_output(monkeypatch, tmp_path, capsys):
+    async def fake_process(url: str, settings: Settings) -> str:
+        return "MD"
+
+    monkeypatch.setattr("f2clipboard.codex_task._process_task", fake_process)
+    out_file = tmp_path / "out.md"
+    codex_task_command("http://task", copy_to_clipboard=False, output=out_file)
+    assert out_file.read_text() == "MD"
+    assert "MD" in capsys.readouterr().out
+
+
 @pytest.mark.vcr()
 def test_fetch_task_html_records_example():
     html = asyncio.run(_fetch_task_html("https://example.com"))


### PR DESCRIPTION
What: add --output option to codex-task command.
Why: enable saving generated Markdown to file.
How to test: pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py README.md
How to test: pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689abb35e8b0832fb87b9b98e8ad1b40