### PR TITLE
📝 : document --no-clipboard option for chat2prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ changes it mentions:
 f2clipboard chat2prompt https://chatgpt.com/share/abcdefg
 ```
 
+The prompt is copied to your clipboard by default. To skip copying, use ``--no-clipboard``:
+
+```bash
+f2clipboard chat2prompt https://chatgpt.com/share/abcdefg --no-clipboard
+```
+
 HTML tags are stripped and block-level elements become newlines to preserve chat formatting.
 
 Specify a different platform with ``--platform``:


### PR DESCRIPTION
what: document --no-clipboard option for chat2prompt
why: show how to skip copying the generated prompt
how to test: pre-commit run --files README.md && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d5a819c70832f847b42b6401fcf48