### PR TITLE
🔒 : support quoted env secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ non-failure state → ignore.
 
 If a log exceeds 150 kB → invoke an LLM (configurable, OpenAI or Anthropic) to summarise the failure.
 
-Secrets such as API tokens are redacted from logs before summarisation or output.
+Secrets such as API tokens are redacted from logs before summarisation or output,
+including quoted environment values.
 
 Emit a Markdown snippet ready for pasting back into Codex:
 
@@ -72,7 +73,7 @@ f2clipboard files --dir path/to/project
 ### M2 (hardening)
 - [x] Playwright headless login for private Codex tasks. 💯
 - [x] Unit tests (pytest + `pytest-recording` vcr). 💯
-- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_`, OpenAI `sk-`, Slack `xoxb-` and `xapp-`, `Bearer` tokens, and base64-like secrets containing `+`, `/` or `=`) while preserving whitespace around `=` and `:`. 💯
+- [x] Secret scanning & redaction (via custom regex; GitHub `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_`, OpenAI `sk-`, Slack `xoxb-` and `xapp-`, `Bearer` tokens, and base64-like secrets containing `+`, `/` or `=`) while preserving whitespace around `=` and `:` and supporting quoted values. 💯
 - [x] AWS access key redaction. 💯
 
 ### M3 (extensibility)

--- a/f2clipboard/secret.py
+++ b/f2clipboard/secret.py
@@ -18,7 +18,7 @@ SECRET_PATTERNS: list[Pattern[str]] = [
     re.compile(
         r"(?i)(?P<key>[\w-]*(?:api|token|secret|password)[\w-]*)"
         r"(?P<pre>\s*)(?P<sep>[:=])(?P<post>\s*)"
-        r"(?P<value>[A-Za-z0-9-_.+/=]{8,})"
+        r"(?P<quote>['\"]?)(?P<value>[A-Za-z0-9-_.+/=]{8,})(?P=quote)"
     ),
 ]
 
@@ -33,9 +33,10 @@ def redact_secrets(text: str) -> str:
     def _repl(match: re.Match[str]) -> str:
         groups = match.groupdict()
         if "key" in groups:
+            quote = groups.get("quote", "")
             return (
                 f"{groups['key']}{groups.get('pre', '')}{groups['sep']}"
-                f"{groups.get('post', '')}***"
+                f"{groups.get('post', '')}{quote}***{quote}"
             )
         token = match.group(0)
         if (

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -77,6 +77,19 @@ def test_redact_env_token_with_special_chars():
     assert "API_TOKEN=***" in redacted
 
 
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ('TOKEN="abcdef123456"', 'TOKEN="***"'),
+        ("TOKEN='abcdef123456'", "TOKEN='***'"),
+    ],
+)
+def test_redact_env_token_with_quotes(text: str, expected: str) -> None:
+    redacted = redact_secrets(text)
+    assert "abcdef123456" not in redacted  # pragma: allowlist secret
+    assert expected in redacted
+
+
 def test_process_task_redacts(monkeypatch):
     async def fake_html(url: str, cookie: str | None = None) -> str:
         return '<a href="https://github.com/o/r/pull/1">PR</a>'


### PR DESCRIPTION
what: handle quoted env assignments in secret redaction; document
why: quoted secrets leaked in logs
how to test: pre-commit run --files f2clipboard/secret.py tests/test_secret.py README.md && pytest -q

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d5a819c70832f847b42b6401fcf48