### PR TITLE
🔧 : – add GitHub user agent header

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ cd f2clipboard
 pip install -e ".[dev]"
 cp .env.example .env  # fill in your tokens
 # Set GITHUB_TOKEN to authenticate GitHub API requests
+# Requests include a 'User-Agent: f2clipboard' header per GitHub guidelines
 # Set OPENAI_API_KEY or ANTHROPIC_API_KEY for log summarisation
 # Set CODEX_COOKIE to access private Codex tasks
 ```

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -111,7 +111,10 @@ def _github_headers(token: str | None) -> dict[str, str]:
 
     The Authorization header is included when a token is supplied.
     """
-    headers = {"Accept": "application/vnd.github+json"}
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "f2clipboard",
+    }
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -9,6 +9,7 @@ from f2clipboard.codex_task import (
     _extract_pr_url,
     _fetch_check_runs,
     _fetch_task_html,
+    _github_headers,
     _parse_pr_url,
     _process_task,
     codex_task_command,
@@ -106,6 +107,15 @@ def test_fetch_check_runs_includes_token(monkeypatch):
     monkeypatch.setattr("f2clipboard.codex_task.httpx.AsyncClient", DummyClient)
     asyncio.run(_fetch_check_runs("https://github.com/o/r/pull/1", "tok"))
     assert captured["headers"]["Authorization"] == "Bearer tok"
+    assert captured["headers"]["User-Agent"] == "f2clipboard"
+
+
+def test_github_headers_without_token() -> None:
+    headers = _github_headers(None)
+    assert headers == {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "f2clipboard",
+    }
 
 
 def test_decode_log_handles_gzip():


### PR DESCRIPTION
what: send 'User-Agent: f2clipboard' on GitHub API calls.
why: adhere to GitHub API guidelines and aid request tracing.
how to test:
- pre-commit run --files README.md f2clipboard/codex_task.py
  tests/test_codex_task.py
- pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d5a819c70832f847b42b6401fcf48