### PR TITLE
✨: handle bullet lists in chat transcripts

### DIFF
--- a/f2clipboard/chat2prompt.py
+++ b/f2clipboard/chat2prompt.py
@@ -11,9 +11,11 @@ import typer
 
 
 def _extract_text(html_text: str) -> str:
-    """Return plain text from HTML, preserving line breaks."""
+    """Return plain text from HTML, preserving line breaks and bullet points."""
+    html_text = re.sub(r"<li[^>]*>", "\n- ", html_text, flags=re.IGNORECASE)
+    html_text = re.sub(r"</li[^>]*>", "\n", html_text, flags=re.IGNORECASE)
     html_text = re.sub(
-        r"</?(?:br|p|div|li|h[1-6])[^>]*>", "\n", html_text, flags=re.IGNORECASE
+        r"</?(?:br|p|div|h[1-6])[^>]*>", "\n", html_text, flags=re.IGNORECASE
     )
     text = re.sub(r"<[^>]+>", "", html_text)
     text = html.unescape(text)

--- a/tests/test_chat2prompt.py
+++ b/tests/test_chat2prompt.py
@@ -22,6 +22,11 @@ def test_extract_text_preserves_line_breaks():
     assert _extract_text(html) == "Hello\nWorld"
 
 
+def test_extract_text_converts_list_items_to_bullets():
+    html = "<ul><li>One</li><li>Two</li></ul>"
+    assert _extract_text(html) == "- One\n- Two"
+
+
 def test_chat2prompt_command_copies_prompt(monkeypatch, capsys):
     def fake_fetch(url: str, timeout: float) -> str:
         assert url == "http://chat"


### PR DESCRIPTION
## Summary
- preserve bullet lists when converting chat transcript HTML to text
- test list item parsing in chat2prompt

## Testing
- `pre-commit run --files f2clipboard/chat2prompt.py tests/test_chat2prompt.py`
- `pytest -q`
- `git diff --cached | detect-secrets scan -`


------
https://chatgpt.com/codex/tasks/task_e_689d5a819c70832f847b42b6401fcf48