### PR TITLE
Add non-interactive files option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ f2clipboard files --dir path/to/project
 ### M4 (quality of life)
 - [x] Support excluding file patterns in `files` command via `--exclude`. 💯
 - [x] Dry-run option for `files` command to print Markdown instead of copying. 💯
+- [x] Non-interactive mode for `files` command to select all matches via `--all`. 💯
 
 ## Getting Started
 
@@ -158,6 +159,14 @@ Preview output without copying to the clipboard:
 ```bash
 f2clipboard files --dir path/to/project --dry-run
 ```
+
+Select all matched files without prompts:
+
+```bash
+f2clipboard files --dir path/to/project --pattern '*.py' --all
+```
+
+Combine with `--dry-run` to preview the output before copying.
 
 Use brace expansion in patterns to match multiple extensions:
 

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -251,6 +251,11 @@ def build_parser():
         action="store_true",
         help="Print formatted Markdown instead of copying to clipboard",
     )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Select all matched files without prompting",
+    )
     return parser
 
 
@@ -262,8 +267,11 @@ def main(argv=None):
     ignore_patterns = parse_gitignore()
     if args.exclude:
         ignore_patterns.extend(args.exclude)
-    files = list_files(directory, pattern, ignore_patterns)
-    selected_files = select_files(files)
+    files = list(list_files(directory, pattern, ignore_patterns))
+    if args.all:
+        selected_files = files
+    else:
+        selected_files = select_files(files)
 
     if selected_files:
         clipboard_content = format_files_for_clipboard(

--- a/f2clipboard/files.py
+++ b/f2clipboard/files.py
@@ -21,6 +21,9 @@ def files_command(
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print Markdown instead of copying to clipboard"
     ),
+    select_all: bool = typer.Option(
+        False, "--all", help="Select all matched files without prompting"
+    ),
 ) -> None:
     """Invoke the legacy script to copy selected files to the clipboard."""
     script_path = Path(__file__).resolve().parent.parent / "f2clipboard.py"
@@ -40,4 +43,6 @@ def files_command(
         argv.extend(["--exclude", pat])
     if dry_run:
         argv.append("--dry-run")
+    if select_all:
+        argv.append("--all")
     module.main(argv)

--- a/tests/test_files_all.py
+++ b/tests/test_files_all.py
@@ -1,0 +1,75 @@
+import importlib.util
+import types
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from f2clipboard import app
+from f2clipboard import files as files_module
+
+
+def _load_legacy_module():
+    spec = importlib.util.spec_from_file_location(
+        "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_files_command_forwards_all(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_main(argv):
+        called["argv"] = argv
+
+    class FakeLoader:
+        def exec_module(self, module):
+            module.main = fake_main
+
+    class FakeSpec:
+        loader = FakeLoader()
+
+    monkeypatch.setattr(
+        files_module, "spec_from_file_location", lambda name, path: FakeSpec()
+    )
+    monkeypatch.setattr(
+        files_module, "module_from_spec", lambda spec: types.SimpleNamespace()
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["files", "--dir", str(tmp_path), "--pattern", "*.py", "--all"],
+    )
+    assert result.exit_code == 0
+    assert called["argv"] == [
+        "--dir",
+        str(tmp_path),
+        "--pattern",
+        "*.py",
+        "--all",
+    ]
+
+
+def test_legacy_main_all_selects_all(monkeypatch, tmp_path, capsys):
+    (tmp_path / "a.py").write_text("a")
+    (tmp_path / "b.py").write_text("b")
+    legacy = _load_legacy_module()
+
+    def fail_select_files(_files):  # pragma: no cover - should not run
+        raise AssertionError("select_files should not be called")
+
+    monkeypatch.setattr(legacy, "select_files", fail_select_files)
+
+    copied: dict[str, str] = {}
+    monkeypatch.setattr(
+        legacy.clipboard, "copy", lambda content: copied.setdefault("data", content)
+    )
+
+    legacy.main(["--dir", str(tmp_path), "--pattern", "*.py", "--dry-run", "--all"])
+
+    out = capsys.readouterr().out
+    assert "a.py" in out and "b.py" in out
+    assert "data" not in copied


### PR DESCRIPTION
## Summary
- support `--all` flag for selecting all matched files
- document non-interactive file selection

## Testing
- `pre-commit run --files f2clipboard/files.py f2clipboard.py tests/test_files_all.py README.md`
- `pre-commit run --files README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5a7c2ea8832fac84c3f3d14b8423