### PR TITLE
🐛 : – handle invalid UTF-8 in log decoder

### DIFF
--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -102,8 +102,8 @@ def _decode_log(data: bytes) -> str:
     """
 
     if data[:2] == b"\x1f\x8b":  # gzip magic number
-        return gzip.decompress(data).decode()
-    return data.decode()
+        return gzip.decompress(data).decode("utf-8", errors="replace")
+    return data.decode("utf-8", errors="replace")
 
 
 def _github_headers(token: str | None) -> dict[str, str]:

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -117,6 +117,10 @@ def test_decode_log_plain():
     assert _decode_log(b"plain") == "plain"
 
 
+def test_decode_log_invalid_utf8():
+    assert _decode_log(b"\xff\xfe") == "��"
+
+
 def test_download_log_handles_gzip():
     class DummyResponse:
         def __init__(self, data: bytes):


### PR DESCRIPTION
what: handle invalid UTF-8 in log decoding
why: avoid crashes on binary logs
how to test:
- pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py
- pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d5a75f120832f98652433d8de806b