### PR TITLE
🐛: add User-Agent header to GitHub requests

### DIFF
--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -111,7 +111,10 @@ def _github_headers(token: str | None) -> dict[str, str]:
 
     The Authorization header is included when a token is supplied.
     """
-    headers = {"Accept": "application/vnd.github+json"}
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "f2clipboard",
+    }
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -9,6 +9,7 @@ from f2clipboard.codex_task import (
     _extract_pr_url,
     _fetch_check_runs,
     _fetch_task_html,
+    _github_headers,
     _parse_pr_url,
     _process_task,
     codex_task_command,
@@ -106,6 +107,10 @@ def test_fetch_check_runs_includes_token(monkeypatch):
     monkeypatch.setattr("f2clipboard.codex_task.httpx.AsyncClient", DummyClient)
     asyncio.run(_fetch_check_runs("https://github.com/o/r/pull/1", "tok"))
     assert captured["headers"]["Authorization"] == "Bearer tok"
+
+
+def test_github_headers_sets_user_agent():
+    assert _github_headers(None)["User-Agent"] == "f2clipboard"
 
 
 def test_decode_log_handles_gzip():


### PR DESCRIPTION
## Summary
- include default user agent in GitHub API helper
- cover user-agent header with a regression test

## Testing
- `pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5a75f120832f98652433d8de806b