### PR TITLE
🚦: validate positive timeout for chat2prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Specify a different platform with ``--platform``:
 f2clipboard chat2prompt https://chatgpt.com/share/abcdefg --platform anthropic
 ```
 
-Adjust the HTTP timeout (default 10 seconds):
+Adjust the HTTP timeout (must be > 0, default 10 seconds):
 
 ```bash
 f2clipboard chat2prompt https://chatgpt.com/share/abcdefg --timeout 5

--- a/f2clipboard/chat2prompt.py
+++ b/f2clipboard/chat2prompt.py
@@ -48,6 +48,8 @@ def chat2prompt_command(
     ),
 ) -> None:
     """Create a coding prompt from a chat transcript and copy it to the clipboard."""
+    if timeout <= 0:
+        raise typer.BadParameter("timeout must be greater than 0")
     transcript = _fetch_transcript(url, timeout=timeout)
     prompt = _build_prompt(transcript, platform)
     if copy_to_clipboard:

--- a/tests/test_chat2prompt.py
+++ b/tests/test_chat2prompt.py
@@ -1,4 +1,6 @@
 import clipboard
+import pytest
+import typer
 
 from f2clipboard.chat2prompt import (
     _extract_text,
@@ -68,3 +70,8 @@ def test_chat2prompt_command_respects_timeout(monkeypatch):
 
     monkeypatch.setattr("f2clipboard.chat2prompt._fetch_transcript", fake_fetch)
     chat2prompt_command("http://chat", timeout=2, copy_to_clipboard=False)
+
+
+def test_chat2prompt_timeout_must_be_positive():
+    with pytest.raises(typer.BadParameter):
+        chat2prompt_command("http://chat", timeout=0, copy_to_clipboard=False)


### PR DESCRIPTION
## Summary
- reject non-positive --timeout values in chat2prompt command
- document timeout requirement
- test timeout validation

## Testing
- `pre-commit run --files f2clipboard/chat2prompt.py tests/test_chat2prompt.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5a75f120832f98652433d8de806b