### PR TITLE
✨ add --output flag to files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ f2clipboard files --dir path/to/project
 ### M4 (quality of life)
 - [x] Support excluding file patterns in `files` command via `--exclude`. 💯
 - [x] Dry-run option for `files` command to print Markdown instead of copying. 💯
+- [x] Output Markdown to a file in `files` command via `--output`. 💯
 
 ## Getting Started
 
@@ -157,6 +158,12 @@ Preview output without copying to the clipboard:
 
 ```bash
 f2clipboard files --dir path/to/project --dry-run
+```
+
+Write output to a file:
+
+```bash
+f2clipboard files --dir path/to/project --output snippet.md
 ```
 
 Use brace expansion in patterns to match multiple extensions:

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -251,6 +251,10 @@ def build_parser():
         action="store_true",
         help="Print formatted Markdown instead of copying to clipboard",
     )
+    parser.add_argument(
+        "--output",
+        help="Write formatted Markdown to this file",
+    )
     return parser
 
 
@@ -269,6 +273,9 @@ def main(argv=None):
         clipboard_content = format_files_for_clipboard(
             selected_files, directory, ignore_patterns
         )
+        if args.output:
+            with open(args.output, "w") as fh:
+                fh.write(clipboard_content)
         if args.dry_run:
             print(clipboard_content)
         else:

--- a/f2clipboard/files.py
+++ b/f2clipboard/files.py
@@ -21,6 +21,11 @@ def files_command(
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print Markdown instead of copying to clipboard"
     ),
+    output: str | None = typer.Option(
+        None,
+        "--output",
+        help="Write formatted Markdown to this file",
+    ),
 ) -> None:
     """Invoke the legacy script to copy selected files to the clipboard."""
     script_path = Path(__file__).resolve().parent.parent / "f2clipboard.py"
@@ -40,4 +45,6 @@ def files_command(
         argv.extend(["--exclude", pat])
     if dry_run:
         argv.append("--dry-run")
+    if output:
+        argv.extend(["--output", output])
     module.main(argv)

--- a/tests/test_files_output.py
+++ b/tests/test_files_output.py
@@ -1,0 +1,80 @@
+import importlib.util
+import types
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from f2clipboard import app
+from f2clipboard import files as files_module
+
+
+def _load_legacy_module():
+    spec = importlib.util.spec_from_file_location(
+        "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_files_command_forwards_output(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_main(argv):
+        called["argv"] = argv
+
+    class FakeLoader:
+        def exec_module(self, module):
+            module.main = fake_main
+
+    class FakeSpec:
+        loader = FakeLoader()
+
+    monkeypatch.setattr(
+        files_module, "spec_from_file_location", lambda name, path: FakeSpec()
+    )
+    monkeypatch.setattr(
+        files_module, "module_from_spec", lambda spec: types.SimpleNamespace()
+    )
+
+    runner = CliRunner()
+    out_file = tmp_path / "out.md"
+    result = runner.invoke(
+        app, ["files", "--dir", str(tmp_path), "--output", str(out_file)]
+    )
+    assert result.exit_code == 0
+    assert called["argv"] == [
+        "--dir",
+        str(tmp_path),
+        "--pattern",
+        "*",
+        "--output",
+        str(out_file),
+    ]
+
+
+def test_legacy_main_writes_output(monkeypatch, tmp_path):
+    (tmp_path / "a.py").write_text("a")
+    legacy = _load_legacy_module()
+
+    monkeypatch.setattr(legacy, "select_files", lambda files: list(files))
+
+    copied: dict[str, str] = {}
+    monkeypatch.setattr(
+        legacy.clipboard, "copy", lambda content: copied.setdefault("data", content)
+    )
+
+    out_file = tmp_path / "snippet.md"
+    legacy.main(
+        [
+            "--dir",
+            str(tmp_path),
+            "--pattern",
+            "*.py",
+            "--output",
+            str(out_file),
+        ]
+    )
+
+    assert out_file.read_text() == copied["data"]


### PR DESCRIPTION
## Summary
- allow `files` command to write Markdown to a file with `--output`
- document `--output` usage and add regression tests

## Testing
- `pre-commit run --files f2clipboard/files.py f2clipboard.py tests/test_files_output.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5a94bbd0832f98e60e3c59294e6d