### PR TITLE
Add --all flag to files command for non-interactive selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ f2clipboard files --dir path/to/project
 ### M4 (quality of life)
 - [x] Support excluding file patterns in `files` command via `--exclude`. 💯
 - [x] Dry-run option for `files` command to print Markdown instead of copying. 💯
+- [x] Non-interactive flag to select all files in `files` command via `--all`. 💯
 
 ## Getting Started
 
@@ -145,6 +146,12 @@ Copy selected files from a local repository:
 
 ```bash
 f2clipboard files --dir path/to/project
+```
+
+Select all matches without prompting:
+
+```bash
+f2clipboard files --dir path/to/project --all
 ```
 
 Exclude glob patterns by repeating `--exclude`:

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -247,6 +247,11 @@ def build_parser():
         help="Additional glob patterns to ignore (may be repeated)",
     )
     parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Select all matched files without prompting",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Print formatted Markdown instead of copying to clipboard",
@@ -262,8 +267,11 @@ def main(argv=None):
     ignore_patterns = parse_gitignore()
     if args.exclude:
         ignore_patterns.extend(args.exclude)
-    files = list_files(directory, pattern, ignore_patterns)
-    selected_files = select_files(files)
+    files = list(list_files(directory, pattern, ignore_patterns))
+    if args.all:
+        selected_files = files
+    else:
+        selected_files = select_files(files)
 
     if selected_files:
         clipboard_content = format_files_for_clipboard(

--- a/f2clipboard/files.py
+++ b/f2clipboard/files.py
@@ -18,6 +18,9 @@ def files_command(
         "--exclude",
         help="Additional glob patterns to ignore (can be used multiple times)",
     ),
+    all_files: bool = typer.Option(
+        False, "--all", help="Select all matched files without an interactive prompt"
+    ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print Markdown instead of copying to clipboard"
     ),
@@ -38,6 +41,8 @@ def files_command(
     argv = ["--dir", directory, "--pattern", pattern]
     for pat in exclude:
         argv.extend(["--exclude", pat])
+    if all_files:
+        argv.append("--all")
     if dry_run:
         argv.append("--dry-run")
     module.main(argv)

--- a/tests/test_files_all.py
+++ b/tests/test_files_all.py
@@ -1,0 +1,65 @@
+import importlib.util
+import types
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from f2clipboard import app
+from f2clipboard import files as files_module
+
+
+def _load_legacy_module():
+    spec = importlib.util.spec_from_file_location(
+        "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_files_command_forwards_all(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_main(argv):
+        called["argv"] = argv
+
+    class FakeLoader:
+        def exec_module(self, module):
+            module.main = fake_main
+
+    class FakeSpec:
+        loader = FakeLoader()
+
+    monkeypatch.setattr(
+        files_module, "spec_from_file_location", lambda name, path: FakeSpec()
+    )
+    monkeypatch.setattr(
+        files_module, "module_from_spec", lambda spec: types.SimpleNamespace()
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["files", "--dir", str(tmp_path), "--all"])
+    assert result.exit_code == 0
+    assert called["argv"] == ["--dir", str(tmp_path), "--pattern", "*", "--all"]
+
+
+def test_legacy_main_all(monkeypatch, tmp_path):
+    (tmp_path / "a.py").write_text("a")
+    (tmp_path / "b.py").write_text("b")
+    legacy = _load_legacy_module()
+
+    def fail_select(files):
+        raise AssertionError("select_files should not be called")
+
+    monkeypatch.setattr(legacy, "select_files", fail_select)
+
+    copied: dict[str, str] = {}
+    monkeypatch.setattr(
+        legacy.clipboard, "copy", lambda content: copied.setdefault("data", content)
+    )
+
+    legacy.main(["--dir", str(tmp_path), "--pattern", "*.py", "--all"])
+
+    assert "a.py" in copied["data"]
+    assert "b.py" in copied["data"]


### PR DESCRIPTION
## Summary
- support `--all` flag on `files` command to select all matches without a prompt
- document non-interactive usage and mark roadmap item complete
- cover new flag with tests

## Testing
- `pre-commit run --files f2clipboard/files.py f2clipboard.py tests/test_files_all.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d5a94bbd0832f98e60e3c59294e6d