### PR TITLE
✨ add adjustable timeout to codex-task

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ OPENAI_API_KEY=sk-xxx          # optional if using Anthropic
 ANTHROPIC_API_KEY=claude-xxx   # optional alternative
 CODEX_COOKIE=cookie-xxx        # optional; enables Playwright login
 LOG_SIZE_THRESHOLD=150000      # bytes; logs bigger than this get summarised
+HTTP_TIMEOUT=10                # seconds; HTTP request timeout

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ f2clipboard files --dir path/to/project
 ### M4 (quality of life)
 - [x] Support excluding file patterns in `files` command via `--exclude`. 💯
 - [x] Dry-run option for `files` command to print Markdown instead of copying. 💯
+- [x] Adjustable HTTP timeout for `codex-task` command via `--timeout`. 💯
 
 ## Getting Started
 
@@ -95,6 +96,7 @@ cp .env.example .env  # fill in your tokens
 # Set GITHUB_TOKEN to authenticate GitHub API requests
 # Set OPENAI_API_KEY or ANTHROPIC_API_KEY for log summarisation
 # Set CODEX_COOKIE to access private Codex tasks
+# Set HTTP_TIMEOUT to override request timeout (default 10 seconds)
 ```
 
 Generate a Markdown snippet for a Codex task:
@@ -118,6 +120,15 @@ f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --log-size-thres
 ```
 
 The default threshold can also be set via the ``LOG_SIZE_THRESHOLD`` environment variable in
+your ``.env`` file.
+
+Adjust the HTTP request timeout (default 10 seconds):
+
+```bash
+f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --timeout 5
+```
+
+The default timeout can also be set via the ``HTTP_TIMEOUT`` environment variable in
 your ``.env`` file.
 
 Generate a prompt that reads a shared chat transcript and implements any code or configuration

--- a/f2clipboard/config.py
+++ b/f2clipboard/config.py
@@ -16,6 +16,11 @@ class Settings(BaseSettings):
         alias="LOG_SIZE_THRESHOLD",
         description="Summarise logs larger than this many bytes",
     )
+    http_timeout: float = Field(
+        default=10.0,
+        alias="HTTP_TIMEOUT",
+        description="HTTP request timeout in seconds",
+    )
 
     class Config:
         env_file = ".env"

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -78,10 +78,12 @@ def test_redact_env_token_with_special_chars():
 
 
 def test_process_task_redacts(monkeypatch):
-    async def fake_html(url: str, cookie: str | None = None) -> str:
+    async def fake_html(
+        url: str, cookie: str | None = None, timeout: float = 10.0
+    ) -> str:
         return '<a href="https://github.com/o/r/pull/1">PR</a>'
 
-    async def fake_runs(pr_url: str, token: str | None):
+    async def fake_runs(pr_url: str, token: str | None, timeout: float = 10.0):
         return [{"id": 1, "name": "Job", "conclusion": "failure"}]
 
     async def fake_log(client, owner, repo, run_id):


### PR DESCRIPTION
what: allow configuring codex-task HTTP timeout via --timeout and HTTP_TIMEOUT.
why: lets users handle slow networks when fetching logs.
how to test: pre-commit run --files .env.example README.md f2clipboard/codex_task.py f2clipboard/config.py tests/test_codex_task.py tests/test_secret.py && pytest -q.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689d5a94bbd0832f98e60e3c59294e6d