### PR TITLE
✨ Include HEIC images in file exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ Copy selected files from a local repository:
 f2clipboard files --dir path/to/project
 ```
 
+The command skips common binary and image files (for example, `.jpg`, `.png`, `.heic`) so the
+output contains only text-friendly content.
+
 Exclude glob patterns by repeating `--exclude`:
 
 ```bash

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -11,6 +11,7 @@ EXCLUDED_EXTENSIONS = {
     ".jpg",
     ".jpeg",
     ".png",
+    ".heic",
     ".gif",
     ".bmp",
     ".tiff",

--- a/tests/test_is_binary_or_image_file.py
+++ b/tests/test_is_binary_or_image_file.py
@@ -1,0 +1,16 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+spec = spec_from_file_location(
+    "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+)
+module = module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def test_is_binary_or_image_file_identifies_heic():
+    assert module.is_binary_or_image_file("photo.heic")
+
+
+def test_is_binary_or_image_file_allows_text():
+    assert not module.is_binary_or_image_file("notes.txt")


### PR DESCRIPTION
## Summary
- skip `.heic` files when scanning directories
- document automatic filtering of binary/image files
- test binary filter with HEIC example

## Testing
- `pre-commit run --files f2clipboard.py tests/test_is_binary_or_image_file.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb6e28204832f8329c95efb8c8aec