### PR TITLE
✨ : support ordered lists in chat2prompt extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ f2clipboard chat2prompt https://chatgpt.com/share/abcdefg --no-clipboard
 ```
 
 HTML tags are stripped and block-level elements become newlines to preserve chat formatting.
+Unordered lists are converted to `-` bullets and ordered lists become numbered items.
 
 Specify a different platform with ``--platform``:
 

--- a/f2clipboard/chat2prompt.py
+++ b/f2clipboard/chat2prompt.py
@@ -12,6 +12,21 @@ import typer
 
 def _extract_text(html_text: str) -> str:
     """Return plain text from HTML, preserving line breaks and bullet points."""
+
+    def _replace_ordered(match: re.Match[str]) -> str:
+        inner = match.group(1)
+        items = re.findall(
+            r"<li[^>]*>(.*?)</li[^>]*>", inner, flags=re.IGNORECASE | re.DOTALL
+        )
+        numbered = [f"{i}. {item}" for i, item in enumerate(items, 1)]
+        return "\n" + "\n".join(numbered) + "\n"
+
+    html_text = re.sub(
+        r"<ol[^>]*>(.*?)</ol>",
+        _replace_ordered,
+        html_text,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
     html_text = re.sub(r"<li[^>]*>", "\n- ", html_text, flags=re.IGNORECASE)
     html_text = re.sub(r"</li[^>]*>", "\n", html_text, flags=re.IGNORECASE)
     html_text = re.sub(

--- a/tests/test_chat2prompt.py
+++ b/tests/test_chat2prompt.py
@@ -29,6 +29,11 @@ def test_extract_text_converts_list_items_to_bullets():
     assert _extract_text(html) == "- One\n- Two"
 
 
+def test_extract_text_converts_ordered_list_to_numbered_items():
+    html = "<ol><li>First</li><li>Second</li></ol>"
+    assert _extract_text(html) == "1. First\n2. Second"
+
+
 def test_chat2prompt_command_copies_prompt(monkeypatch, capsys):
     def fake_fetch(url: str, timeout: float) -> str:
         assert url == "http://chat"


### PR DESCRIPTION
## Summary
- number ordered list items when converting chat transcripts
- document list formatting for chat2prompt

## Testing
- `pre-commit run --files f2clipboard/chat2prompt.py tests/test_chat2prompt.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb6e28204832f8329c95efb8c8aec