### PR TITLE
Handle query strings in PR URL parser

### DIFF
--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -82,10 +82,11 @@ def _extract_pr_url(html: str) -> str | None:
 def _parse_pr_url(pr_url: str) -> tuple[str, str, int]:
     """Extract owner, repo and pull number from a PR URL.
 
-    Trailing slashes are tolerated and ignored.
+    Trailing slashes, query strings and fragments are tolerated and ignored.
     """
+    pr_url = pr_url.split("?", 1)[0].split("#", 1)[0].rstrip("/")
     pattern = (
-        r"https://github.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)/?"
+        r"https://github.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)"
     )
     match = re.match(pattern, pr_url)
     if not match:  # pragma: no cover - defensive programming

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -42,6 +42,15 @@ def test_parse_pr_url_trailing_slash() -> None:
     )
 
 
+def test_parse_pr_url_with_query_and_fragment() -> None:
+    url = "https://github.com/owner/repo/pull/42/?w=1#discussion"
+    assert _parse_pr_url(url) == (
+        "owner",
+        "repo",
+        42,
+    )
+
+
 def test_fetch_check_runs_parses_response(monkeypatch):
     class DummyResponse:
         def __init__(self, data):


### PR DESCRIPTION
## Summary
- allow `_parse_pr_url` to ignore query strings and fragments
- add test coverage for PR URLs with query or fragment components

## Testing
- `pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py`
- `pytest -q`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689eb6e28204832f8329c95efb8c8aec