### PR TITLE
🔧: ignore whitespace-only tokens in GitHub headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ cd f2clipboard
 pip install -e ".[dev]"
 cp .env.example .env  # fill in your tokens
 # Set GITHUB_TOKEN to authenticate GitHub API requests
+# Whitespace-only values are ignored
 # Set OPENAI_API_KEY or ANTHROPIC_API_KEY for log summarisation
 # Set CODEX_COOKIE to access private Codex tasks
 ```

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -110,11 +110,13 @@ def _github_headers(token: str | None) -> dict[str, str]:
     """Return standard headers for GitHub API requests.
 
     The Authorization header is included when a token is supplied.
+    Whitespace-only tokens are ignored.
     """
     headers = {
         "Accept": "application/vnd.github+json",
         "User-Agent": "f2clipboard",
     }
+    token = token.strip() if token else None
     if token:
         headers["Authorization"] = f"Bearer {token}"
     return headers

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -113,6 +113,11 @@ def test_github_headers_sets_user_agent():
     assert _github_headers(None)["User-Agent"] == "f2clipboard"
 
 
+def test_github_headers_ignores_blank_token() -> None:
+    """Whitespace-only tokens should not add Authorization header."""
+    assert "Authorization" not in _github_headers("   ")
+
+
 def test_decode_log_handles_gzip():
     data = gzip.compress(b"hello")
     assert _decode_log(data) == "hello"


### PR DESCRIPTION
what: ignore whitespace-only tokens when building Authorization header
why: prevent malformed Bearer headers
how to test: pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py README.md && pytest -q


------
https://chatgpt.com/codex/tasks/task_e_689eb6e28204832f8329c95efb8c8aec