### PR TITLE
Add plugin count option to f2clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ f2clipboard files --dir path/to/project
 - [x] Dry-run option for `files` command to print Markdown instead of copying. 💯
 - [x] JSON output option for `plugins` command. 💯
 - [x] Non-interactive mode for `files` command to select all matches via `--all`. 💯
+- [x] Plugin count via `plugins --count`. 💯
 
 ## Getting Started
 
@@ -220,6 +221,12 @@ Output as JSON:
 
 ```bash
 f2clipboard plugins --json
+```
+
+Show the number of installed plugins:
+
+```bash
+f2clipboard plugins --count
 ```
 
 The first bundled plugin summarises Jira issues:

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -26,16 +26,23 @@ _loaded_plugins: list[str] = []
 def plugins_command(
     json_output: bool = typer.Option(
         False, "--json", help="Output plugin names as JSON."
-    )
+    ),
+    count: bool = typer.Option(
+        False, "--count", help="Print the number of installed plugins."
+    ),
 ) -> None:
-    """List registered plugin names."""
+    """List registered plugin names or counts."""
     if not _loaded_plugins:
-        if json_output:
+        if count:
+            typer.echo("0")
+        elif json_output:
             typer.echo("[]")
         else:
             typer.echo("No plugins installed")
         return
-    if json_output:
+    if count:
+        typer.echo(str(len(_loaded_plugins)))
+    elif json_output:
         typer.echo(json.dumps(_loaded_plugins))
     else:
         for name in _loaded_plugins:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -83,3 +83,34 @@ def test_plugins_command_json_no_plugins(monkeypatch):
     result = runner.invoke(f2clipboard.app, ["plugins", "--json"])
     assert result.exit_code == 0
     assert result.stdout.strip() == "[]"
+
+
+def test_plugins_command_count(monkeypatch):
+    ep = EntryPoint(
+        name="sample", value="tests.test_plugins:plugin", group="f2clipboard.plugins"
+    )
+
+    def fake_entry_points(*args, **kwargs):
+        if kwargs.get("group") == "f2clipboard.plugins":
+            return [ep]
+        return []
+
+    importlib.reload(f2clipboard)
+    monkeypatch.setattr(f2clipboard, "entry_points", fake_entry_points)
+    f2clipboard._loaded_plugins = []
+    f2clipboard._load_plugins()
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--count"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "1"
+
+
+def test_plugins_command_count_no_plugins(monkeypatch):
+    importlib.reload(f2clipboard)
+    monkeypatch.setattr(f2clipboard, "entry_points", lambda *a, **k: [])
+    f2clipboard._loaded_plugins = []
+    f2clipboard._load_plugins()
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--count"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "0"


### PR DESCRIPTION
## Summary
- add `--count` flag to `plugins` command to print installed plugin count
- document and test plugin counting

## Testing
- `pre-commit run --files README.md f2clipboard/__init__.py tests/test_plugins.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb6e6f874832f8af28049a3cdd516