### PR TITLE
✨ add --output option to files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ f2clipboard files --dir path/to/project
 ### M4 (quality of life)
 - [x] Support excluding file patterns in `files` command via `--exclude`. 💯
 - [x] Dry-run option for `files` command to print Markdown instead of copying. 💯
+- [x] Save `files` command output to a file via `--output`. 💯
 - [x] JSON output option for `plugins` command. 💯
 - [x] Non-interactive mode for `files` command to select all matches via `--all`. 💯
 
@@ -166,6 +167,12 @@ Preview output without copying to the clipboard:
 
 ```bash
 f2clipboard files --dir path/to/project --dry-run
+```
+
+Save output to a Markdown file:
+
+```bash
+f2clipboard files --dir path/to/project --output snippet.md
 ```
 
 Select all matched files without prompts:

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -256,6 +256,10 @@ def build_parser():
         action="store_true",
         help="Select all matched files without prompting",
     )
+    parser.add_argument(
+        "--output",
+        help="Write formatted Markdown to a file instead of copying to clipboard",
+    )
     return parser
 
 
@@ -277,7 +281,11 @@ def main(argv=None):
         clipboard_content = format_files_for_clipboard(
             selected_files, directory, ignore_patterns
         )
-        if args.dry_run:
+        if args.output:
+            with open(args.output, "w", encoding="utf-8") as f:
+                f.write(clipboard_content)
+            print(f"📄 The formatted files have been written to {args.output}.")
+        elif args.dry_run:
             print(clipboard_content)
         else:
             clipboard.copy(clipboard_content)

--- a/f2clipboard/files.py
+++ b/f2clipboard/files.py
@@ -24,6 +24,11 @@ def files_command(
     select_all: bool = typer.Option(
         False, "--all", help="Select all matched files without prompting"
     ),
+    output: str | None = typer.Option(
+        None,
+        "--output",
+        help="Write Markdown output to a file instead of copying to clipboard",
+    ),
 ) -> None:
     """Invoke the legacy script to copy selected files to the clipboard."""
     script_path = Path(__file__).resolve().parent.parent / "f2clipboard.py"
@@ -45,4 +50,6 @@ def files_command(
         argv.append("--dry-run")
     if select_all:
         argv.append("--all")
+    if output is not None:
+        argv.extend(["--output", output])
     module.main(argv)

--- a/tests/test_files_output.py
+++ b/tests/test_files_output.py
@@ -1,0 +1,77 @@
+import importlib.util
+import types
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from f2clipboard import app
+from f2clipboard import files as files_module
+
+
+def _load_legacy_module():
+    spec = importlib.util.spec_from_file_location(
+        "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_files_command_forwards_output(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_main(argv):
+        called["argv"] = argv
+
+    class FakeLoader:
+        def exec_module(self, module):
+            module.main = fake_main
+
+    class FakeSpec:
+        loader = FakeLoader()
+
+    monkeypatch.setattr(
+        files_module, "spec_from_file_location", lambda name, path: FakeSpec()
+    )
+    monkeypatch.setattr(
+        files_module, "module_from_spec", lambda spec: types.SimpleNamespace()
+    )
+
+    runner = CliRunner()
+    out_file = tmp_path / "out.md"
+    result = runner.invoke(
+        app, ["files", "--dir", str(tmp_path), "--output", str(out_file)]
+    )
+    assert result.exit_code == 0
+    assert called["argv"] == [
+        "--dir",
+        str(tmp_path),
+        "--pattern",
+        "*",
+        "--output",
+        str(out_file),
+    ]
+
+
+def test_legacy_main_writes_output_file(monkeypatch, tmp_path, capsys):
+    (tmp_path / "a.py").write_text("a")
+    legacy = _load_legacy_module()
+    monkeypatch.setattr(legacy, "select_files", lambda files: list(files))
+
+    copied = {}
+    monkeypatch.setattr(
+        legacy.clipboard, "copy", lambda content: copied.setdefault("data", content)
+    )
+
+    out_file = tmp_path / "out.md"
+    legacy.main(
+        ["--dir", str(tmp_path), "--pattern", "*.py", "--output", str(out_file)]
+    )
+
+    out = capsys.readouterr().out
+    assert out_file.exists()
+    assert str(out_file) in out
+    content = out_file.read_text()
+    assert "a.py" in content
+    assert "data" not in copied


### PR DESCRIPTION
## What
- add `--output` flag to `files` command to save markdown to file
- document new option and mark roadmap

## Why
- enable capturing file snippets without relying on clipboard

## How to Test
- `pre-commit run --files f2clipboard/files.py f2clipboard.py tests/test_files_output.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb6e6f874832f8af28049a3cdd516