### PR TITLE
✨ Add include patterns for files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ f2clipboard files --dir path/to/project
 - [x] JSON output option for `plugins` command. 💯
 - [x] Non-interactive mode for `files` command to select all matches via `--all`. 💯
 - [x] Plugin count via `plugins --count`. 💯
+- [x] Include additional file patterns in `files` command via `--include`. 💯
 
 ## Getting Started
 
@@ -167,6 +168,12 @@ Exclude glob patterns by repeating `--exclude`:
 
 ```bash
 f2clipboard files --dir path/to/project --exclude 'node_modules/*' --exclude '*.log'
+```
+
+Include extra glob patterns by repeating `--include`:
+
+```bash
+f2clipboard files --pattern '*.py' --include '*.md' --include '*.txt'
 ```
 
 Preview output without copying to the clipboard:

--- a/f2clipboard/files.py
+++ b/f2clipboard/files.py
@@ -13,6 +13,11 @@ def files_command(
     pattern: str = typer.Option(
         "*", "--pattern", help="File glob pattern to match (e.g. *.py)"
     ),
+    include: list[str] = typer.Option(
+        [],
+        "--include",
+        help="Additional glob patterns to include (can be used multiple times)",
+    ),
     exclude: list[str] = typer.Option(
         [],
         "--exclude",
@@ -44,6 +49,8 @@ def files_command(
     module = module_from_spec(spec)
     spec.loader.exec_module(module)
     argv = ["--dir", directory, "--pattern", pattern]
+    for pat in include:
+        argv.extend(["--include", pat])
     for pat in exclude:
         argv.extend(["--exclude", pat])
     if dry_run:

--- a/tests/test_files_include.py
+++ b/tests/test_files_include.py
@@ -1,0 +1,99 @@
+import importlib.util
+import types
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from f2clipboard import app
+from f2clipboard import files as files_module
+
+
+def _load_legacy_module():
+    spec = importlib.util.spec_from_file_location(
+        "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_list_files_supports_include(tmp_path):
+    (tmp_path / "a.py").write_text("a")
+    (tmp_path / "b.txt").write_text("b")
+    (tmp_path / "c.md").write_text("c")
+    legacy = _load_legacy_module()
+    files = list(
+        legacy.list_files(str(tmp_path), pattern="*.py", include_patterns=["*.txt"])
+    )
+    assert str(tmp_path / "a.py") in files
+    assert str(tmp_path / "b.txt") in files
+    assert str(tmp_path / "c.md") not in files
+
+
+def test_files_command_forwards_include(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_main(argv):
+        called["argv"] = argv
+
+    class FakeLoader:
+        def exec_module(self, module):
+            module.main = fake_main
+
+    class FakeSpec:
+        loader = FakeLoader()
+
+    monkeypatch.setattr(
+        files_module, "spec_from_file_location", lambda name, path: FakeSpec()
+    )
+    monkeypatch.setattr(
+        files_module, "module_from_spec", lambda spec: types.SimpleNamespace()
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "files",
+            "--dir",
+            str(tmp_path),
+            "--pattern",
+            "*.py",
+            "--include",
+            "*.txt",
+            "--include",
+            "*.md",
+        ],
+    )
+    assert result.exit_code == 0
+    assert called["argv"] == [
+        "--dir",
+        str(tmp_path),
+        "--pattern",
+        "*.py",
+        "--include",
+        "*.txt",
+        "--include",
+        "*.md",
+    ]
+
+
+def test_legacy_main_uses_include(monkeypatch, tmp_path):
+    (tmp_path / "a.py").write_text("a")
+    (tmp_path / "b.txt").write_text("b")
+    (tmp_path / "c.md").write_text("c")
+    legacy = _load_legacy_module()
+
+    monkeypatch.setattr(legacy, "select_files", lambda files: list(files))
+
+    copied: dict[str, str] = {}
+    monkeypatch.setattr(
+        legacy.clipboard, "copy", lambda content: copied.setdefault("data", content)
+    )
+
+    legacy.main(["--dir", str(tmp_path), "--pattern", "*.py", "--include", "*.txt"])
+
+    assert "a.py" in copied["data"]
+    assert "b.txt" in copied["data"]
+    assert "- [x] c.md" not in copied["data"]


### PR DESCRIPTION
## Summary
- allow extra include patterns in files command
- document include usage and mark roadmap item
- cover include patterns with tests

## Testing
- `pre-commit run --files README.md f2clipboard.py f2clipboard/files.py tests/test_files_include.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f8acef344832f941b3d32456795cb