### PR TITLE
✨ : add sort option for plugins command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ f2clipboard files --dir path/to/project
 - [x] Plugin count via `plugins --count`. 💯
 - [x] Show plugin versions via `plugins --versions`. 💯
 - [x] Include additional file patterns in `files` command via `--include`. 💯
+- [x] Sort plugin names via `plugins --sort`. 💯
 
 ## Getting Started
 
@@ -235,6 +236,12 @@ List installed plugins:
 
 ```bash
 f2clipboard plugins
+```
+
+Sort them alphabetically:
+
+```bash
+f2clipboard plugins --sort
 ```
 
 Output as JSON:

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -33,6 +33,9 @@ def plugins_command(
         False, "--count", help="Print the number of installed plugins."
     ),
     versions: bool = typer.Option(False, "--versions", help="Show plugin versions."),
+    sort: bool = typer.Option(
+        False, "--sort", help="Sort plugin names alphabetically."
+    ),
 ) -> None:
     """List registered plugin names, counts or versions."""
     if not _loaded_plugins:
@@ -43,18 +46,20 @@ def plugins_command(
         else:
             typer.echo("No plugins installed")
         return
+    names = sorted(_loaded_plugins) if sort else list(_loaded_plugins)
     if count:
         typer.echo(str(len(_loaded_plugins)))
     elif json_output:
         if versions:
-            typer.echo(json.dumps(_plugin_versions))
+            data = {name: _plugin_versions.get(name, "unknown") for name in names}
+            typer.echo(json.dumps(data))
         else:
-            typer.echo(json.dumps(_loaded_plugins))
+            typer.echo(json.dumps(names))
     elif versions:
-        for name in _loaded_plugins:
+        for name in names:
             typer.echo(f"{name} {_plugin_versions.get(name, 'unknown')}")
     else:
-        for name in _loaded_plugins:
+        for name in names:
             typer.echo(name)
 
 


### PR DESCRIPTION
what: allow sorting plugin list and versions
why: easier to scan installed plugins
how to test:
- pre-commit run --files README.md f2clipboard/__init__.py tests/test_plugins.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68a00fab1f4c832fbf8ba6bf53519580