### PR TITLE
✨: allow selecting language model for summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ cp .env.example .env  # fill in your tokens
 # Set GITHUB_TOKEN to authenticate GitHub API requests
 # Whitespace-only values are ignored
 # Set OPENAI_API_KEY or ANTHROPIC_API_KEY for log summarisation
+# Set OPENAI_MODEL or ANTHROPIC_MODEL to choose the summarisation model
 # Set CODEX_COOKIE to access private Codex tasks
 ```
 
@@ -117,6 +118,12 @@ To skip copying to the clipboard, pass ``--no-clipboard``:
 
 ```bash
 f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --no-clipboard
+```
+
+Override the default model with ``--openai-model`` or ``--anthropic-model``:
+
+```bash
+f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --openai-model gpt-4o-mini
 ```
 
 Adjust the log size threshold for summarisation with ``--log-size-threshold``:

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -190,6 +190,14 @@ def codex_task_command(
             help="Summarise logs larger than this many bytes.",
         ),
     ] = None,
+    openai_model: Annotated[
+        str | None,
+        typer.Option("--openai-model", help="OpenAI model for summarising logs."),
+    ] = None,
+    anthropic_model: Annotated[
+        str | None,
+        typer.Option("--anthropic-model", help="Anthropic model for summarising logs."),
+    ] = None,
 ) -> None:
     """Parse a Codex task page and print any failing GitHub checks.
 
@@ -197,10 +205,14 @@ def codex_task_command(
     Use ``--log-size-threshold`` to override the summarisation threshold.
     """
     typer.echo(f"Parsing Codex task page: {url}…")
+    settings_kwargs = {}
     if log_size_threshold is not None:
-        settings = Settings(LOG_SIZE_THRESHOLD=log_size_threshold)
-    else:
-        settings = Settings()  # load environment (e.g. GITHUB_TOKEN)
+        settings_kwargs["LOG_SIZE_THRESHOLD"] = log_size_threshold
+    if openai_model is not None:
+        settings_kwargs["OPENAI_MODEL"] = openai_model
+    if anthropic_model is not None:
+        settings_kwargs["ANTHROPIC_MODEL"] = anthropic_model
+    settings = Settings(**settings_kwargs) if settings_kwargs else Settings()
     result = asyncio.run(_process_task(url, settings))
     if copy_to_clipboard:
         clipboard.copy(result)

--- a/f2clipboard/config.py
+++ b/f2clipboard/config.py
@@ -10,6 +10,10 @@ class Settings(BaseSettings):
     github_token: str | None = Field(default=None, alias="GITHUB_TOKEN")
     openai_api_key: str | None = Field(default=None, alias="OPENAI_API_KEY")
     anthropic_api_key: str | None = Field(default=None, alias="ANTHROPIC_API_KEY")
+    openai_model: str = Field(default="gpt-3.5-turbo", alias="OPENAI_MODEL")
+    anthropic_model: str = Field(
+        default="claude-3-haiku-20240307", alias="ANTHROPIC_MODEL"
+    )
     codex_cookie: str | None = Field(default=None, alias="CODEX_COOKIE")
     log_size_threshold: int = Field(
         default=150_000,

--- a/tests/test_openai_model_override.py
+++ b/tests/test_openai_model_override.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from f2clipboard.config import Settings
+from f2clipboard.llm import summarise_log
+
+
+def test_openai_model_override(monkeypatch):
+    called: dict[str, str] = {}
+
+    async def fake_summarise_openai(text: str, api_key: str, model: str) -> str:
+        called["model"] = model
+        return "summary"
+
+    monkeypatch.setattr("f2clipboard.llm._summarise_openai", fake_summarise_openai)
+    settings = Settings(OPENAI_API_KEY="key", OPENAI_MODEL="gpt-4o-mini")
+    result = asyncio.run(summarise_log("log text", settings))
+    assert result == "summary"
+    assert called["model"] == "gpt-4o-mini"


### PR DESCRIPTION
what: allow configuring OpenAI/Anthropic models via env vars or flags.
why: customise summarisation LLM for file-based tasks.
how to test:
 - pre-commit run --files f2clipboard/config.py f2clipboard/llm.py f2clipboard/codex_task.py README.md tests/test_openai_model_override.py
 - pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a00f7f0868832f91e63cf21b87b667