### PR TITLE
🛡️: strip gitignore inline comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ f2clipboard files --dir path/to/project
 ```
 
 The command skips common binary and image files (for example, `.jpg`, `.png`, `.heic`) so the
-output contains only text-friendly content.
+output contains only text-friendly content. It also honours patterns from `.gitignore`,
+stripping any inline `#` comments.
 
 Exclude glob patterns by repeating `--exclude`:
 

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -1,6 +1,7 @@
 import argparse
 import fnmatch
 import os
+import re
 import shutil
 
 import clipboard
@@ -56,16 +57,19 @@ EXCLUDED_EXTENSIONS = {
 
 
 def parse_gitignore(gitignore_path=".gitignore"):
-    """Parse the .gitignore file and return a list of patterns, including '.git' always."""
-    patterns = [".git"]  # Always ignore .git directory
+    """Parse the .gitignore file and return a list of patterns.
+
+    The `.git` directory is always ignored. Inline comments beginning with `#` are stripped,
+    and escaped hashes ('\\#') are unescaped.
+    """
+
+    patterns = [".git"]
     if os.path.exists(gitignore_path):
         with open(gitignore_path, "r") as file:
-            lines = file.readlines()
-
-        for line in lines:
-            stripped = line.strip()
-            if stripped and not stripped.startswith("#"):
-                patterns.append(stripped)
+            for line in file:
+                cleaned = re.sub(r"(?<!\\)#.*", "", line).strip().replace("\\#", "#")
+                if cleaned:
+                    patterns.append(cleaned)
     return patterns
 
 

--- a/tests/test_parse_gitignore.py
+++ b/tests/test_parse_gitignore.py
@@ -1,0 +1,18 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+def load_module():
+    spec = spec_from_file_location(
+        "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+    )
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_gitignore_strips_inline_comments(tmp_path):
+    gitignore = tmp_path / ".gitignore"
+    gitignore.write_text("foo\nbar # note\nbaz\\#qux\n")
+    module = load_module()
+    assert module.parse_gitignore(str(gitignore)) == [".git", "foo", "bar", "baz#qux"]


### PR DESCRIPTION
## Summary
- ignore inline `#` comments and unescape hashes when parsing `.gitignore`
- mention `.gitignore` support in README
- cover inline-comment handling with a new test

## Testing
- `pre-commit run --files f2clipboard.py tests/test_parse_gitignore.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a00f7f0868832f91e63cf21b87b667