### PR TITLE
🧹 : skip macOS .DS_Store files

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ Copy selected files from a local repository:
 f2clipboard files --dir path/to/project
 ```
 
-The command skips common binary and image files (for example, `.jpg`, `.png`, `.heic`) so the
-output contains only text-friendly content.
+The command skips common binary, image, and system files (for example, `.jpg`, `.png`, `.heic`,
+`.DS_Store`) so the output contains only text-friendly content.
 
 Exclude glob patterns by repeating `--exclude`:
 

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -52,6 +52,8 @@ EXCLUDED_EXTENSIONS = {
     ".psd",
     ".ai",
     ".sketch",
+    # System files
+    ".ds_store",
 }
 
 

--- a/tests/test_is_binary_or_image_file.py
+++ b/tests/test_is_binary_or_image_file.py
@@ -14,3 +14,7 @@ def test_is_binary_or_image_file_identifies_heic():
 
 def test_is_binary_or_image_file_allows_text():
     assert not module.is_binary_or_image_file("notes.txt")
+
+
+def test_is_binary_or_image_file_skips_ds_store():
+    assert module.is_binary_or_image_file(".DS_Store")


### PR DESCRIPTION
what: ignore macOS .DS_Store in legacy file workflow
why: prevents copying metadata files
how to test:
- pre-commit run --files f2clipboard.py tests/test_is_binary_or_image_file.py README.md
- pytest -q

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a00f7f0868832f91e63cf21b87b667