### PR TITLE
🐛: avoid duplicate plugin loading

### DIFF
--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -83,12 +83,14 @@ def _load_plugins() -> None:
     """Load registered entry-point plugins."""
     for ep in entry_points(group="f2clipboard.plugins"):
         try:
+            if ep.name in _loaded_plugins:
+                # Skip already loaded plugins to avoid duplicate command registration
+                continue
             plugin = ep.load()
             plugin(app)
-            if ep.name not in _loaded_plugins:
-                _loaded_plugins.append(ep.name)
-                dist = getattr(ep, "dist", None)
-                _plugin_versions[ep.name] = getattr(dist, "version", "unknown")
+            _loaded_plugins.append(ep.name)
+            dist = getattr(ep, "dist", None)
+            _plugin_versions[ep.name] = getattr(dist, "version", "unknown")
         except Exception as exc:  # pragma: no cover - defensive
             logging.getLogger(__name__).warning(
                 "Failed to load plugin %s: %s", ep.name, exc


### PR DESCRIPTION
## Summary
- skip already-loaded plugins to prevent duplicate command registration
- test plugin loader idempotency

## Testing
- `pre-commit run --files f2clipboard/__init__.py tests/test_plugins.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a00f7f0868832f91e63cf21b87b667