### PR TITLE
Include GitHub API version header

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ f2clipboard files --dir path/to/project
 - [x] Fetch PR URL from Codex task HTML (unauthenticated test page). 💯
 
 ### M1 (minimum lovable product)
-- [x] Parse check-suites with GitHub REST v3. 💯
+- [x] Parse check-suites with GitHub REST v3 (API version 2022-11-28). 💯
 - [x] Download raw logs; gzip-decode when necessary. 💯
 - [x] Size-gate logs → summarise via LLM. 💯
 - [x] Write Markdown artefact to `stdout` **and** clipboard. 💯

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -21,6 +21,7 @@ except ImportError:  # pragma: no cover - Playwright may be missing
     async_playwright = None  # type: ignore[assignment]
 
 GITHUB_API = "https://api.github.com"
+GITHUB_API_VERSION = "2022-11-28"
 
 # GitHub check-run conclusions considered failing. Other states such as
 # "success", "neutral" or "skipped" are ignored when gathering logs.
@@ -116,6 +117,7 @@ def _github_headers(token: str | None) -> dict[str, str]:
     headers = {
         "Accept": "application/vnd.github+json",
         "User-Agent": "f2clipboard",
+        "X-GitHub-Api-Version": GITHUB_API_VERSION,
     }
     token = token.strip() if token else None
     if token:

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -122,6 +122,11 @@ def test_github_headers_sets_user_agent():
     assert _github_headers(None)["User-Agent"] == "f2clipboard"
 
 
+def test_github_headers_sets_api_version() -> None:
+    """GitHub API version header should be included."""
+    assert _github_headers(None)["X-GitHub-Api-Version"] == "2022-11-28"
+
+
 def test_github_headers_ignores_blank_token() -> None:
     """Whitespace-only tokens should not add Authorization header."""
     assert "Authorization" not in _github_headers("   ")


### PR DESCRIPTION
## Summary
- add X-GitHub-Api-Version header to GitHub requests
- document pinned API version
- cover headers with unit test

## Testing
- `pre-commit run --files f2clipboard/codex_task.py README.md`
- `pytest -q`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a57c3a89f8832f80a8dfc369bc59c6