### PR TITLE
📝 : honour ordered list start in chat2prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,8 @@ f2clipboard chat2prompt https://chatgpt.com/share/abcdefg --no-clipboard
 ```
 
 HTML tags are stripped and block-level elements become newlines to preserve chat formatting.
-Unordered lists are converted to `-` bullets and ordered lists become numbered items.
+Unordered lists are converted to `-` bullets and ordered lists become numbered items,
+honouring any HTML `start` attributes.
 
 Specify a different platform with ``--platform``:
 

--- a/f2clipboard/chat2prompt.py
+++ b/f2clipboard/chat2prompt.py
@@ -14,11 +14,14 @@ def _extract_text(html_text: str) -> str:
     """Return plain text from HTML, preserving line breaks and bullet points."""
 
     def _replace_ordered(match: re.Match[str]) -> str:
+        outer = match.group(0)
         inner = match.group(1)
+        start_match = re.search(r"start=['\"]?(\d+)['\"]?", outer, flags=re.IGNORECASE)
+        start = int(start_match.group(1)) if start_match else 1
         items = re.findall(
             r"<li[^>]*>(.*?)</li[^>]*>", inner, flags=re.IGNORECASE | re.DOTALL
         )
-        numbered = [f"{i}. {item}" for i, item in enumerate(items, 1)]
+        numbered = [f"{i}. {item}" for i, item in enumerate(items, start)]
         return "\n" + "\n".join(numbered) + "\n"
 
     html_text = re.sub(

--- a/tests/test_chat2prompt.py
+++ b/tests/test_chat2prompt.py
@@ -34,6 +34,11 @@ def test_extract_text_converts_ordered_list_to_numbered_items():
     assert _extract_text(html) == "1. First\n2. Second"
 
 
+def test_extract_text_respects_ordered_list_start():
+    html = '<ol start="3"><li>First</li><li>Second</li></ol>'
+    assert _extract_text(html) == "3. First\n4. Second"
+
+
 def test_chat2prompt_command_copies_prompt(monkeypatch, capsys):
     def fake_fetch(url: str, timeout: float) -> str:
         assert url == "http://chat"


### PR DESCRIPTION
## Summary
- honour <ol start> when flattening ordered lists
- document and test ordered list start behaviour

## Testing
- `pre-commit run --files f2clipboard/chat2prompt.py tests/test_chat2prompt.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a57c3a89f8832f80a8dfc369bc59c6