### PR TITLE
✨: support JSON output for plugin counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ Show the number of installed plugins:
 f2clipboard plugins --count
 ```
 
+Output the plugin count as JSON:
+
+```bash
+f2clipboard plugins --count --json
+```
+
 Show plugin versions:
 
 ```bash

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -39,7 +39,10 @@ def plugins_command(
 ) -> None:
     """List registered plugin names, counts or versions."""
     if not _loaded_plugins:
-        if count:
+        count_value = 0
+        if count and json_output:
+            typer.echo(json.dumps({"count": count_value}))
+        elif count:
             typer.echo("0")
         elif json_output:
             typer.echo("{}" if versions else "[]")
@@ -47,7 +50,9 @@ def plugins_command(
             typer.echo("No plugins installed")
         return
     names = sorted(_loaded_plugins) if sort else list(_loaded_plugins)
-    if count:
+    if count and json_output:
+        typer.echo(json.dumps({"count": len(_loaded_plugins)}))
+    elif count:
         typer.echo(str(len(_loaded_plugins)))
     elif json_output:
         if versions:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -153,6 +153,18 @@ def test_plugins_command_count_no_plugins(monkeypatch):
     assert result.stdout.strip() == "0"
 
 
+def test_plugins_command_count_json_no_plugins(monkeypatch):
+    importlib.reload(f2clipboard)
+    monkeypatch.setattr(f2clipboard, "entry_points", lambda *a, **k: [])
+    f2clipboard._loaded_plugins = []
+    f2clipboard._plugin_versions = {}
+    f2clipboard._load_plugins()
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--count", "--json"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == '{"count": 0}'
+
+
 def test_plugins_command_versions(monkeypatch):
     ep = EntryPoint(
         name="sample", value="tests.test_plugins:plugin", group="f2clipboard.plugins"


### PR DESCRIPTION
## Summary
- allow combining `--count` and `--json` for structured plugin totals
- document JSON plugin count usage
- test `plugins --count --json` when no plugins installed

## Testing
- `pre-commit run --files f2clipboard/__init__.py tests/test_plugins.py README.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a57c3a89f8832f80a8dfc369bc59c6