### PR TITLE
Add reverse option to plugin command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ f2clipboard files --dir path/to/project
 - [x] Plugin count via `plugins --count`. 💯
 - [x] Show plugin versions via `plugins --versions`. 💯
 - [x] Include additional file patterns in `files` command via `--include`. 💯
-- [x] Sort plugin names via `plugins --sort`. 💯
+- [x] Sort plugin names via `plugins --sort` (use `--reverse` for reverse order). 💯
 
 ## Getting Started
 
@@ -246,10 +246,22 @@ List installed plugins:
 f2clipboard plugins
 ```
 
+Reverse the default order:
+
+```bash
+f2clipboard plugins --reverse
+```
+
 Sort them alphabetically:
 
 ```bash
 f2clipboard plugins --sort
+```
+
+Sort them in reverse alphabetical order:
+
+```bash
+f2clipboard plugins --sort --reverse
 ```
 
 Output as JSON:

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -36,6 +36,7 @@ def plugins_command(
     sort: bool = typer.Option(
         False, "--sort", help="Sort plugin names alphabetically."
     ),
+    reverse: bool = typer.Option(False, "--reverse", help="Reverse plugin order."),
 ) -> None:
     """List registered plugin names, counts or versions."""
     if not _loaded_plugins:
@@ -46,7 +47,12 @@ def plugins_command(
         else:
             typer.echo("No plugins installed")
         return
-    names = sorted(_loaded_plugins) if sort else list(_loaded_plugins)
+    if sort:
+        names = sorted(_loaded_plugins, reverse=reverse)
+    elif reverse:
+        names = list(reversed(_loaded_plugins))
+    else:
+        names = list(_loaded_plugins)
     if count:
         typer.echo(str(len(_loaded_plugins)))
     elif json_output:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -271,3 +271,19 @@ def test_plugins_command_versions_json_sort(monkeypatch):
     )
     assert result.exit_code == 0
     assert result.stdout.strip() == '{"alpha": "unknown", "zeta": "unknown"}'
+
+
+def test_plugins_command_reverse(monkeypatch):
+    _setup_two_plugins(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--reverse"])
+    assert result.exit_code == 0
+    assert result.stdout.strip().splitlines() == ["alpha", "zeta"]
+
+
+def test_plugins_command_sort_reverse(monkeypatch):
+    _setup_two_plugins(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--sort", "--reverse"])
+    assert result.exit_code == 0
+    assert result.stdout.strip().splitlines() == ["zeta", "alpha"]


### PR DESCRIPTION
## Summary
- add --reverse flag for plugin order
- document reverse sorting in README

## Testing
- `pre-commit run --files f2clipboard/__init__.py tests/test_plugins.py README.md`
- `pre-commit run --files README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a57c3a89f8832f80a8dfc369bc59c6