### PR TITLE
Add filter option to plugins command

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ f2clipboard files --dir path/to/project
 - [x] Show plugin versions via `plugins --versions`. 💯
 - [x] Include additional file patterns in `files` command via `--include`. 💯
 - [x] Sort plugin names via `plugins --sort`. 💯
+- [x] Filter plugin names via `plugins --filter`. 💯
 
 ## Getting Started
 
@@ -250,6 +251,12 @@ Sort them alphabetically:
 
 ```bash
 f2clipboard plugins --sort
+```
+
+Filter by substring:
+
+```bash
+f2clipboard plugins --filter jira
 ```
 
 Output as JSON:

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -36,6 +36,9 @@ def plugins_command(
     sort: bool = typer.Option(
         False, "--sort", help="Sort plugin names alphabetically."
     ),
+    filter_: str | None = typer.Option(
+        None, "--filter", help="Only include plugin names containing this substring."
+    ),
 ) -> None:
     """List registered plugin names, counts or versions."""
     if not _loaded_plugins:
@@ -46,9 +49,21 @@ def plugins_command(
         else:
             typer.echo("No plugins installed")
         return
-    names = sorted(_loaded_plugins) if sort else list(_loaded_plugins)
+    names = list(_loaded_plugins)
+    if filter_:
+        names = [name for name in names if filter_ in name]
+    if not names:
+        if count:
+            typer.echo("0")
+        elif json_output:
+            typer.echo("{}" if versions else "[]")
+        else:
+            typer.echo("No plugins installed")
+        return
+    if sort:
+        names = sorted(names)
     if count:
-        typer.echo(str(len(_loaded_plugins)))
+        typer.echo(str(len(names)))
     elif json_output:
         if versions:
             data = {name: _plugin_versions.get(name, "unknown") for name in names}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -271,3 +271,27 @@ def test_plugins_command_versions_json_sort(monkeypatch):
     )
     assert result.exit_code == 0
     assert result.stdout.strip() == '{"alpha": "unknown", "zeta": "unknown"}'
+
+
+def test_plugins_command_filter(monkeypatch):
+    _setup_two_plugins(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--filter", "alpha"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "alpha"
+
+
+def test_plugins_command_json_filter(monkeypatch):
+    _setup_two_plugins(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--json", "--filter", "z"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == '["zeta"]'
+
+
+def test_plugins_command_filter_no_match(monkeypatch):
+    _setup_two_plugins(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--filter", "beta"])
+    assert result.exit_code == 0
+    assert "No plugins installed" in result.stdout


### PR DESCRIPTION
## Summary
- allow filtering plugin names via `plugins --filter`
- document new option and update roadmap

## Testing
- `pre-commit run --files README.md f2clipboard/__init__.py tests/test_plugins.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a57c40fb74832f9b07576899e18ec5