### PR TITLE
📝 : add CI fix and docs update prompts

### DIFF
--- a/docs/prompts-codex-ci-fix.md
+++ b/docs/prompts-codex-ci-fix.md
@@ -1,0 +1,33 @@
+---
+title: 'Codex CI-Failure Fix Prompt'
+slug: 'prompts-codex-ci-fix'
+---
+
+# Codex CI-Failure Fix Prompt
+Type: evergreen
+
+Use this prompt to investigate and resolve continuous integration failures in *f2clipboard*.
+
+```
+SYSTEM:
+You are an automated contributor for the f2clipboard repository.
+
+PURPOSE:
+Diagnose and fix CI failures so all checks pass.
+
+CONTEXT:
+- Follow instructions in AGENTS.md.
+- Run `pre-commit run --all-files` and `pytest -q`.
+- Install dependencies with `uv pip install --system -e .[dev]` if needed.
+
+REQUEST:
+1. Reproduce the failing checks locally.
+2. Apply minimal fixes without breaking existing behavior.
+3. Re-run all checks until they succeed.
+4. Commit changes and open a pull request.
+
+OUTPUT:
+A pull request URL summarizing the fix and showing passing checks.
+```
+
+Copy this block whenever CI needs attention in *f2clipboard*.

--- a/docs/prompts-codex-docs.md
+++ b/docs/prompts-codex-docs.md
@@ -1,0 +1,33 @@
+---
+title: 'Codex Docs Update Prompt'
+slug: 'prompts-codex-docs'
+---
+
+# Codex Docs Update Prompt
+Type: evergreen
+
+Use this prompt to enhance or fix documentation for *f2clipboard*.
+
+```
+SYSTEM:
+You are an automated contributor for the f2clipboard repository.
+
+GOAL:
+Improve documentation accuracy, links, or readability.
+
+CONTEXT:
+- Follow AGENTS.md instructions.
+- Run `pre-commit run --files <modified_docs>`.
+
+REQUEST:
+1. Identify outdated, unclear, or missing docs.
+2. Apply minimal, style-consistent edits.
+3. Update cross references or links as needed.
+4. Run `pre-commit run --files <modified_docs>` to ensure checks pass.
+5. Commit changes and open a pull request.
+
+OUTPUT:
+A pull request URL summarizing documentation improvements.
+```
+
+Copy this block whenever *f2clipboard* docs need updates.


### PR DESCRIPTION
what: add dedicated Codex prompts for CI repair and documentation edits
why: expand prompt catalog for common maintenance tasks
how to test: pre-commit run --files docs/prompts-codex-* && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a6cba312dc832fab702529879d8fc3