### PR TITLE
Add case-insensitive filter for plugins command

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,10 +254,10 @@ Sort them alphabetically:
 f2clipboard plugins --sort
 ```
 
-Filter by substring:
+Filter by substring (case-insensitive with `--ignore-case`):
 
 ```bash
-f2clipboard plugins --filter jira
+f2clipboard plugins --filter jira --ignore-case
 ```
 
 Output as JSON:

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -38,6 +38,9 @@ def plugins_command(
     filter_: str | None = typer.Option(
         None, "--filter", help="Only include plugin names containing this substring."
     ),
+    ignore_case: bool = typer.Option(
+        False, "--ignore-case", help="Filter plugin names case-insensitively."
+    ),
 ) -> None:
     """List registered plugin names, counts or versions."""
 
@@ -57,7 +60,11 @@ def plugins_command(
     # Start from loaded plugins, then apply filter & sort deterministically
     names = list(_loaded_plugins)
     if filter_:
-        names = [name for name in names if filter_ in name]
+        if ignore_case:
+            needle = filter_.lower()
+            names = [name for name in names if needle in name.lower()]
+        else:
+            names = [name for name in names if filter_ in name]
 
     # If filter removes everything, mirror empty behavior again
     if not names:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -301,6 +301,26 @@ def test_plugins_command_json_filter(monkeypatch):
     assert result.stdout.strip() == '["zeta"]'
 
 
+def test_plugins_command_filter_ignore_case(monkeypatch):
+    _setup_two_plugins(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        f2clipboard.app, ["plugins", "--filter", "ALPHA", "--ignore-case"]
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == "alpha"
+
+
+def test_plugins_command_json_filter_ignore_case(monkeypatch):
+    _setup_two_plugins(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(
+        f2clipboard.app, ["plugins", "--json", "--filter", "Z", "--ignore-case"]
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == '["zeta"]'
+
+
 def test_plugins_command_filter_no_match(monkeypatch):
     _setup_two_plugins(monkeypatch)
     runner = CliRunner()


### PR DESCRIPTION
## What
- add --ignore-case flag to plugins command
- document case-insensitive plugin filtering

## Why
- improves plugin discovery when casing differs

## How to Test
- pre-commit run --files f2clipboard/__init__.py README.md tests/test_plugins.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68a80b3e29dc832fb4f4e099394142c9