### PR TITLE
✨ : include plugin names in JSON count output

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,10 +272,14 @@ Show the number of installed plugins:
 f2clipboard plugins --count
 ```
 
-Output the plugin count as JSON:
+Output the plugin count as JSON (including plugin names):
 
 ```bash
 f2clipboard plugins --count --json
+```
+
+```json
+{"count": 1, "plugins": ["jira"]}
 ```
 
 Show plugin versions:

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -45,7 +45,8 @@ def plugins_command(
     if not _loaded_plugins:
         count_value = 0
         if count and json_output:
-            typer.echo(json.dumps({"count": count_value}))
+            payload = {"count": count_value, "plugins": {} if versions else []}
+            typer.echo(json.dumps(payload))
         elif count:
             typer.echo("0")
         elif json_output:
@@ -62,7 +63,8 @@ def plugins_command(
     # If filter removes everything, mirror empty behavior again
     if not names:
         if count and json_output:
-            typer.echo(json.dumps({"count": 0}))
+            payload = {"count": 0, "plugins": {} if versions else []}
+            typer.echo(json.dumps(payload))
         elif count:
             typer.echo("0")
         elif json_output:
@@ -76,7 +78,13 @@ def plugins_command(
 
     # Counts should reflect the (possibly filtered) list.
     if count and json_output:
-        typer.echo(json.dumps({"count": len(names)}))
+        if versions:
+            plugins_data = {
+                name: _plugin_versions.get(name, "unknown") for name in names
+            }
+        else:
+            plugins_data = names
+        typer.echo(json.dumps({"count": len(names), "plugins": plugins_data}))
     elif count:
         typer.echo(str(len(names)))
     elif json_output:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -162,7 +162,51 @@ def test_plugins_command_count_json_no_plugins(monkeypatch):
     runner = CliRunner()
     result = runner.invoke(f2clipboard.app, ["plugins", "--count", "--json"])
     assert result.exit_code == 0
-    assert result.stdout.strip() == '{"count": 0}'
+    assert result.stdout.strip() == '{"count": 0, "plugins": []}'
+
+
+def test_plugins_command_count_json(monkeypatch):
+    ep = EntryPoint(
+        name="sample", value="tests.test_plugins:plugin", group="f2clipboard.plugins"
+    )
+
+    def fake_entry_points(*args, **kwargs):
+        if kwargs.get("group") == "f2clipboard.plugins":
+            return [ep]
+        return []
+
+    importlib.reload(f2clipboard)
+    monkeypatch.setattr(f2clipboard, "entry_points", fake_entry_points)
+    f2clipboard._loaded_plugins = []
+    f2clipboard._plugin_versions = {}
+    f2clipboard._load_plugins()
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--count", "--json"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == '{"count": 1, "plugins": ["sample"]}'
+
+
+def test_plugins_command_count_versions_json(monkeypatch):
+    ep = EntryPoint(
+        name="sample", value="tests.test_plugins:plugin", group="f2clipboard.plugins"
+    )
+
+    def fake_entry_points(*args, **kwargs):
+        if kwargs.get("group") == "f2clipboard.plugins":
+            return [ep]
+        return []
+
+    importlib.reload(f2clipboard)
+    monkeypatch.setattr(f2clipboard, "entry_points", fake_entry_points)
+    f2clipboard._loaded_plugins = []
+    f2clipboard._plugin_versions = {}
+    f2clipboard._load_plugins()
+    runner = CliRunner()
+    result = runner.invoke(
+        f2clipboard.app, ["plugins", "--count", "--versions", "--json"]
+    )
+    assert result.exit_code == 0
+    assert result.stdout.strip() == '{"count": 1, "plugins": {"sample": "unknown"}}'
 
 
 def test_plugins_command_versions(monkeypatch):


### PR DESCRIPTION
what: expose plugin list and versions in `plugins --count --json`
why: aid automation needing both count and names
how to test: pytest
Refs: #none

------
https://chatgpt.com/codex/tasks/task_e_68a80b3e29dc832fb4f4e099394142c9