### PR TITLE
✨ : expose plugin paths via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ f2clipboard files --dir path/to/project
 - [x] Non-interactive mode for `files` command to select all matches via `--all`. 💯
 - [x] Plugin count via `plugins --count`. 💯
 - [x] Show plugin versions via `plugins --versions`. 💯
+- [x] Show plugin file paths via `plugins --paths`. 💯
 - [x] Include additional file patterns in `files` command via `--include`. 💯
 - [x] Sort plugin names via `plugins --sort`. 💯
 - [x] Filter plugin names via `plugins --filter`. 💯
@@ -288,6 +289,18 @@ Output versions as JSON:
 
 ```bash
 f2clipboard plugins --versions --json
+```
+
+Show plugin source paths:
+
+```bash
+f2clipboard plugins --paths
+```
+
+Output paths as JSON:
+
+```bash
+f2clipboard plugins --paths --json
 ```
 
 The first bundled plugin summarises Jira issues:


### PR DESCRIPTION
## Summary
- add `--paths` option to `plugins` command to show plugin source paths
- document new flag and cover with tests

## Testing
- `pre-commit run --files f2clipboard/__init__.py tests/test_plugins.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a80b459658832fbd6df27c119131d1