### PR TITLE
✨ : summarise large logs with LLM

### DIFF
--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -169,11 +169,13 @@ async def _process_task(url: str, settings: Settings) -> str:
             if len(log_text.encode()) > settings.log_size_threshold:
                 summary = await summarise_log(log_text, settings)
                 snippet = "\n".join(log_text.splitlines()[:100])
-                log_text = (
+                rendered = (
                     f"{summary}\n\n<details>\n<summary>First 100 lines</summary>\n\n"
                     f"```text\n{snippet}\n```\n</details>"
                 )
-            sections.append(f"### {run['name']}\n\n```text\n{log_text}\n```")
+            else:
+                rendered = f"```text\n{log_text}\n```"
+            sections.append(f"### {run['name']}\n\n{rendered}")
 
     return "\n\n".join(sections) or "No failing checks"
 

--- a/f2clipboard/config.py
+++ b/f2clipboard/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     codex_cookie: str | None = Field(default=None, alias="CODEX_COOKIE")
     log_size_threshold: int = Field(
         default=150_000,
+        ge=0,
         alias="LOG_SIZE_THRESHOLD",
         description="Summarise logs larger than this many bytes",
     )

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -170,7 +170,7 @@ def test_process_task_summarises_large_log(monkeypatch):
         return [{"id": 1, "name": "Job", "conclusion": "failure"}]
 
     async def fake_log(client, owner, repo, run_id):
-        return "log line\n" * 200  # large
+        return "\n".join(f"line {i}" for i in range(1, 201))  # large
 
     async def fake_summary(text: str, settings: Settings) -> str:
         return "SUMMARY"
@@ -183,8 +183,10 @@ def test_process_task_summarises_large_log(monkeypatch):
     settings = Settings()
     settings.log_size_threshold = 100
     result = asyncio.run(_process_task("http://task", settings))
-    assert "SUMMARY" in result
-    assert "<details>" in result
+    assert "SUMMARY\n\n<details>" in result
+    assert "line 1" in result
+    assert "line 100" in result
+    assert "line 101" not in result
 
 
 def test_process_task_small_log_skips_summarise(monkeypatch):


### PR DESCRIPTION
## Summary
- summarise oversized check-run logs with default LLM
- show first 100 lines in collapsible block
- enforce non-negative log threshold

## Testing
- `pre-commit run --files f2clipboard/codex_task.py f2clipboard/config.py tests/test_codex_task.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8116a8930832fa133d2bcc584641e