### PR TITLE
Add reverse option for plugins command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ f2clipboard files --dir path/to/project
 - [x] Show plugin file paths via `plugins --paths`. 💯
 - [x] Include additional file patterns in `files` command via `--include`. 💯
 - [x] Sort plugin names via `plugins --sort`. 💯
+- [x] Reverse plugin names via `plugins --reverse`. 💯
 - [x] Filter plugin names via `plugins --filter`. 💯
 
 ## Getting Started
@@ -253,6 +254,18 @@ Sort them alphabetically:
 
 ```bash
 f2clipboard plugins --sort
+```
+
+Reverse the order of plugins:
+
+```bash
+f2clipboard plugins --reverse
+```
+
+Sort descending:
+
+```bash
+f2clipboard plugins --sort --reverse
 ```
 
 Filter by substring (case-insensitive with `--ignore-case`):

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -38,6 +38,7 @@ def plugins_command(
     sort: bool = typer.Option(
         False, "--sort", help="Sort plugin names alphabetically."
     ),
+    reverse: bool = typer.Option(False, "--reverse", help="Reverse plugin order."),
     filter_: str | None = typer.Option(
         None, "--filter", help="Only include plugin names containing this substring."
     ),
@@ -85,6 +86,9 @@ def plugins_command(
 
     if sort:
         names = sorted(names)
+
+    if reverse:
+        names = list(reversed(names))
 
     # Counts should reflect the (possibly filtered) list.
     if count and json_output:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -402,6 +402,22 @@ def test_plugins_command_versions_json_sort(monkeypatch):
     assert result.stdout.strip() == '{"alpha": "unknown", "zeta": "unknown"}'
 
 
+def test_plugins_command_reverse(monkeypatch):
+    _setup_two_plugins(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--reverse"])
+    assert result.exit_code == 0
+    assert result.stdout.strip().splitlines() == ["alpha", "zeta"]
+
+
+def test_plugins_command_sort_reverse(monkeypatch):
+    _setup_two_plugins(monkeypatch)
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--sort", "--reverse"])
+    assert result.exit_code == 0
+    assert result.stdout.strip().splitlines() == ["zeta", "alpha"]
+
+
 def test_plugins_command_filter(monkeypatch):
     _setup_two_plugins(monkeypatch)
     runner = CliRunner()


### PR DESCRIPTION
## Summary
- allow reversing plugin order via `plugins --reverse`
- document the new option and mark roadmap item complete

## Testing
- `pre-commit run --files f2clipboard/__init__.py tests/test_plugins.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a92ca0d6ac832fb2b9715a84dbf245