### PR TITLE
✨ : – add --max-size filter to files command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ f2clipboard files --dir path/to/project
 - [x] Include additional file patterns in `files` command via `--include`. 💯
 - [x] Sort plugin names via `plugins --sort`. 💯
 - [x] Filter plugin names via `plugins --filter`. 💯
+- [x] Skip files larger than a threshold via `--max-size`. 💯
 
 ## Getting Started
 
@@ -193,6 +194,12 @@ Preview output without copying to the clipboard:
 
 ```bash
 f2clipboard files --dir path/to/project --dry-run
+```
+
+Skip files larger than a given number of bytes:
+
+```bash
+f2clipboard files --dir path/to/project --max-size 1000
 ```
 
 Save output to a Markdown file:

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -94,8 +94,15 @@ def expand_pattern(pattern):
     return [f"{prefix}{opt}{suffix}" for opt in options]
 
 
-def list_files(directory, pattern="*", include_patterns=None, ignore_patterns=[]):
-    """Recursively list files in a directory matching any of the patterns, skipping ignored and binary/image files."""
+def list_files(
+    directory,
+    pattern="*",
+    include_patterns=None,
+    ignore_patterns=[],
+    max_size=None,
+):
+    """Recursively list files in a directory matching any of the patterns, skipping ignored,
+    binary/image files, and files larger than ``max_size`` bytes."""
     # Expand brace patterns into multiple patterns
     patterns = expand_pattern(pattern)
     if include_patterns:
@@ -125,6 +132,9 @@ def list_files(directory, pattern="*", include_patterns=None, ignore_patterns=[]
 
             # Skip binary/image files
             if is_binary_or_image_file(basename):
+                continue
+
+            if max_size is not None and os.path.getsize(filename) > max_size:
                 continue
 
             # Match if the file matches any of the expanded patterns
@@ -276,6 +286,11 @@ def build_parser():
         "--output",
         help="Write formatted Markdown to a file instead of copying to clipboard",
     )
+    parser.add_argument(
+        "--max-size",
+        type=int,
+        help="Skip files larger than this size in bytes",
+    )
     return parser
 
 
@@ -293,6 +308,7 @@ def main(argv=None):
             pattern=pattern,
             include_patterns=args.include,
             ignore_patterns=ignore_patterns,
+            max_size=args.max_size,
         )
     )
     if args.all:

--- a/f2clipboard/files.py
+++ b/f2clipboard/files.py
@@ -23,6 +23,11 @@ def files_command(
         "--exclude",
         help="Additional glob patterns to ignore (can be used multiple times)",
     ),
+    max_size: int | None = typer.Option(
+        None,
+        "--max-size",
+        help="Skip files larger than this size in bytes",
+    ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Print Markdown instead of copying to clipboard"
     ),
@@ -53,6 +58,8 @@ def files_command(
         argv.extend(["--include", pat])
     for pat in exclude:
         argv.extend(["--exclude", pat])
+    if max_size is not None:
+        argv.extend(["--max-size", str(max_size)])
     if dry_run:
         argv.append("--dry-run")
     if select_all:

--- a/tests/test_files_max_size.py
+++ b/tests/test_files_max_size.py
@@ -1,0 +1,77 @@
+import importlib.util
+import types
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from f2clipboard import app
+from f2clipboard import files as files_module
+
+
+def _load_legacy_module():
+    spec = importlib.util.spec_from_file_location(
+        "legacy_f2clipboard", Path(__file__).resolve().parents[1] / "f2clipboard.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_files_command_forwards_max_size(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_main(argv):
+        called["argv"] = argv
+
+    class FakeLoader:
+        def exec_module(self, module):
+            module.main = fake_main
+
+    class FakeSpec:
+        loader = FakeLoader()
+
+    monkeypatch.setattr(
+        files_module, "spec_from_file_location", lambda name, path: FakeSpec()
+    )
+    monkeypatch.setattr(
+        files_module, "module_from_spec", lambda spec: types.SimpleNamespace()
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["files", "--dir", str(tmp_path), "--max-size", "5"],
+    )
+    assert result.exit_code == 0
+    assert called["argv"] == [
+        "--dir",
+        str(tmp_path),
+        "--pattern",
+        "*",
+        "--max-size",
+        "5",
+    ]
+
+
+def test_legacy_main_max_size(tmp_path, capsys):
+    (tmp_path / "small.txt").write_text("a")
+    (tmp_path / "large.txt").write_text("b" * 10)
+    legacy = _load_legacy_module()
+
+    legacy.main(
+        [
+            "--dir",
+            str(tmp_path),
+            "--pattern",
+            "*.txt",
+            "--all",
+            "--dry-run",
+            "--max-size",
+            "5",
+        ]
+    )
+    out = capsys.readouterr().out
+    selected = out.split("## Selected Files\n", 1)[1]
+    assert "small.txt" in selected
+    assert "large.txt" not in selected


### PR DESCRIPTION
what: allow skipping files over a byte threshold via --max-size.
why: prevents copying huge files.
how to test: pre-commit run --files README.md f2clipboard.py f2clipboard/files.py tests/test_files_max_size.py && pytest -q.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a92ca0d6ac832fb2b9715a84dbf245