### PR TITLE
📝 : clarify log summarisation behaviour

### DIFF
--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -167,6 +167,10 @@ async def _process_task(url: str, settings: Settings) -> str:
             log_text = await _download_log(client, owner, repo, run["id"])
             log_text = redact_secrets(log_text)
             if len(log_text.encode()) > settings.log_size_threshold:
+                # For oversized logs, delegate to the configured LLM to produce a concise
+                # summary and only retain a short snippet of the original output for
+                # context. This keeps the resulting Markdown manageable while still
+                # exposing the most relevant lines.
                 summary = await summarise_log(log_text, settings)
                 snippet = "\n".join(log_text.splitlines()[:100])
                 rendered = (

--- a/f2clipboard/config.py
+++ b/f2clipboard/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
         default="claude-3-haiku-20240307", alias="ANTHROPIC_MODEL"
     )
     codex_cookie: str | None = Field(default=None, alias="CODEX_COOKIE")
+    # Size in bytes above which logs are summarised instead of included verbatim.
     log_size_threshold: int = Field(
         default=150_000,
         ge=0,

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -163,6 +163,8 @@ def test_download_log_handles_gzip():
 
 
 def test_process_task_summarises_large_log(monkeypatch):
+    """Oversized logs should be summarised with the first lines preserved."""
+
     async def fake_html(url: str, cookie: str | None = None) -> str:
         return '<a href="https://github.com/o/r/pull/1">PR</a>'
 


### PR DESCRIPTION
## What
- document LLM summarisation of large logs

## Why
- clarify how oversize logs are handled

## How to Test
- `pre-commit run --files f2clipboard/codex_task.py f2clipboard/config.py tests/test_codex_task.py`
- `pytest -q`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a92ca718ec832fa65a32d2183d1d5d