### PR TITLE
✨ : copy codex-task result to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123
 ```
 
 The resulting Markdown is printed to your terminal and copied to the clipboard.
+Paste it:
+
+```bash
+pbpaste  # macOS
+# xclip -o -selection clipboard  # Linux
+```
 For a list of available options, run ``f2clipboard codex-task --help``.
 To skip copying to the clipboard, pass ``--no-clipboard``:
 

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -7,8 +7,8 @@ import gzip
 import re
 from typing import Annotated, Any
 
-import clipboard
 import httpx
+import pyperclip
 import typer
 
 from .config import Settings
@@ -219,5 +219,8 @@ def codex_task_command(
     settings = Settings(**settings_kwargs) if settings_kwargs else Settings()
     result = asyncio.run(_process_task(url, settings))
     if copy_to_clipboard:
-        clipboard.copy(result)
+        try:
+            pyperclip.copy(result)
+        except pyperclip.PyperclipException as exc:
+            typer.echo(f"Warning: failed to copy to clipboard: {exc}", err=True)
     typer.echo(result)

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -1,6 +1,7 @@
 import asyncio
 import gzip
 
+import pyperclip
 import pytest
 
 from f2clipboard.codex_task import (
@@ -252,7 +253,7 @@ def test_codex_task_command_copies_to_clipboard(monkeypatch, capsys):
     def fake_copy(text: str) -> None:
         copied["text"] = text
 
-    monkeypatch.setattr("f2clipboard.codex_task.clipboard.copy", fake_copy)
+    monkeypatch.setattr("f2clipboard.codex_task.pyperclip.copy", fake_copy)
     codex_task_command("http://task")
     out = capsys.readouterr().out
     assert "MD" in out
@@ -269,11 +270,26 @@ def test_codex_task_command_skips_clipboard(monkeypatch, capsys):
     def fake_copy(text: str) -> None:
         copied["text"] = text
 
-    monkeypatch.setattr("f2clipboard.codex_task.clipboard.copy", fake_copy)
+    monkeypatch.setattr("f2clipboard.codex_task.pyperclip.copy", fake_copy)
     codex_task_command("http://task", copy_to_clipboard=False)
     out = capsys.readouterr().out
     assert "MD" in out
     assert not copied
+
+
+def test_codex_task_command_warns_on_clipboard_error(monkeypatch, capsys):
+    async def fake_process(url: str, settings: Settings) -> str:
+        return "MD"
+
+    def fake_copy(text: str) -> None:
+        raise pyperclip.PyperclipException("no clipboard")
+
+    monkeypatch.setattr("f2clipboard.codex_task._process_task", fake_process)
+    monkeypatch.setattr("f2clipboard.codex_task.pyperclip.copy", fake_copy)
+    codex_task_command("http://task")
+    captured = capsys.readouterr()
+    assert "MD" in captured.out
+    assert "Warning" in captured.err
 
 
 def test_codex_task_command_overrides_threshold(monkeypatch, capsys):


### PR DESCRIPTION
what: use pyperclip to copy Markdown and warn if clipboard unavailable
why: preserve stdout output without crashing when utilities are missing
how to test:
- pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py README.md
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68a92ca7bf40832fbcd3307ff0981b01