### PR TITLE
✨: Copy Codex markdown to clipboard via pyperclip

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123
 ```
 
 The resulting Markdown is printed to your terminal and copied to the clipboard.
+View the copied Markdown:
+
+```bash
+pbpaste                          # macOS
+xclip -o -selection clipboard    # Linux
+```
+
 For a list of available options, run ``f2clipboard codex-task --help``.
 To skip copying to the clipboard, pass ``--no-clipboard``:
 

--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -7,8 +7,8 @@ import gzip
 import re
 from typing import Annotated, Any
 
-import clipboard
 import httpx
+import pyperclip
 import typer
 
 from .config import Settings
@@ -219,5 +219,10 @@ def codex_task_command(
     settings = Settings(**settings_kwargs) if settings_kwargs else Settings()
     result = asyncio.run(_process_task(url, settings))
     if copy_to_clipboard:
-        clipboard.copy(result)
+        try:
+            pyperclip.copy(result)
+        except pyperclip.PyperclipException as exc:
+            import warnings
+
+            warnings.warn(f"Could not copy to clipboard: {exc}", RuntimeWarning)
     typer.echo(result)

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -1,6 +1,7 @@
 import asyncio
 import gzip
 
+import pyperclip
 import pytest
 
 from f2clipboard.codex_task import (
@@ -252,7 +253,7 @@ def test_codex_task_command_copies_to_clipboard(monkeypatch, capsys):
     def fake_copy(text: str) -> None:
         copied["text"] = text
 
-    monkeypatch.setattr("f2clipboard.codex_task.clipboard.copy", fake_copy)
+    monkeypatch.setattr("f2clipboard.codex_task.pyperclip.copy", fake_copy)
     codex_task_command("http://task")
     out = capsys.readouterr().out
     assert "MD" in out
@@ -269,11 +270,27 @@ def test_codex_task_command_skips_clipboard(monkeypatch, capsys):
     def fake_copy(text: str) -> None:
         copied["text"] = text
 
-    monkeypatch.setattr("f2clipboard.codex_task.clipboard.copy", fake_copy)
+    monkeypatch.setattr("f2clipboard.codex_task.pyperclip.copy", fake_copy)
     codex_task_command("http://task", copy_to_clipboard=False)
     out = capsys.readouterr().out
     assert "MD" in out
     assert not copied
+
+
+def test_codex_task_command_warns_on_missing_clipboard(monkeypatch, capsys):
+    async def fake_process(url: str, settings: Settings) -> str:
+        return "MD"
+
+    monkeypatch.setattr("f2clipboard.codex_task._process_task", fake_process)
+
+    def fake_copy(text: str) -> None:
+        raise pyperclip.PyperclipException("no xclip")
+
+    monkeypatch.setattr("f2clipboard.codex_task.pyperclip.copy", fake_copy)
+    with pytest.warns(RuntimeWarning, match="clipboard"):
+        codex_task_command("http://task")
+    out = capsys.readouterr().out
+    assert "MD" in out
 
 
 def test_codex_task_command_overrides_threshold(monkeypatch, capsys):


### PR DESCRIPTION
## Summary
- use pyperclip to copy codex-task output
- warn when clipboard copy fails
- document how to view copied Markdown
- import warnings locally to appease lint

## Testing
- `pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a92ca7bf40832fbcd3307ff0981b01