### PR TITLE
✨ : – Add YAML output for plugins command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ f2clipboard files --dir path/to/project
 - [x] Dry-run option for `files` command to print Markdown instead of copying. 💯
 - [x] Save `files` command output to a file via `--output`. 💯
 - [x] JSON output option for `plugins` command. 💯
+- [x] YAML output option for `plugins` command. 💯
 - [x] Non-interactive mode for `files` command to select all matches via `--all`. 💯
 - [x] Plugin count via `plugins --count`. 💯
 - [x] Show plugin versions via `plugins --versions`. 💯
@@ -291,6 +292,12 @@ Output as JSON:
 
 ```bash
 f2clipboard plugins --json
+```
+
+Output as YAML:
+
+```bash
+f2clipboard plugins --yaml
 ```
 
 Show the number of installed plugins:


### PR DESCRIPTION
What: introduce --yaml flag to plugins command with docs and tests.
Why: provide YAML alternative to JSON for plugin listings.
How to test: pre-commit run --files f2clipboard/__init__.py tests/test_plugins.py README.md && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68aa99bb97a4832fba70f0189d19bde5