### PR TITLE
📝 : – cross-link contributing guide and action docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 # Contributing
 
 1. Fork and clone the repository.
-2. Run `pre-commit run --files <modified_files>` and `pytest -q` before opening a pull request.
-3. Describe your changes clearly.
+2. Review [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) and [AGENTS.md](AGENTS.md).
+3. Run `pre-commit run --files <modified_files>` and `pytest -q` before opening a pull request.
+4. Describe your changes clearly.

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -1,7 +1,8 @@
 # GitHub Action
 
-The repository includes a composite action that runs the `f2clipboard` CLI.
-Use it in your workflows to generate Codex summaries or copy files to the
+The repository includes a composite action ([action.yml](../action.yml)) that runs the
+`f2clipboard` CLI. See the README's [GitHub Action section](../README.md#github-action) for an
+overview. Use the action in your workflows to generate Codex summaries or copy files to the
 clipboard.
 
 ```yaml


### PR DESCRIPTION
what: reference CODE_OF_CONDUCT and AGENTS in contributing guide.
 link action docs to action.yml and README.
why: clarify expectations and improve navigation.
how: pre-commit run --files CONTRIBUTING.md docs/github-action.md && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68aa99d5c170832fa8a005ebc6b77925