### PR TITLE
📝: clarify GitHub Action env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Run `f2clipboard` inside GitHub Actions using the bundled composite action:
 ```
 
 Pass any CLI arguments via `args`; the default is `--help`.
+See [docs/github-action.md](docs/github-action.md) for authentication options and more details.
 
 ## Plugins
 

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -8,7 +8,11 @@ clipboard.
 - uses: futuroptimist/f2clipboard@v1
   with:
     args: codex-task https://chatgpt.com/codex/tasks/task_123 --no-clipboard
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 ```
 
-The `args` input accepts any arguments supported by the CLI and defaults to
+The `env` block passes tokens such as `GITHUB_TOKEN` for GitHub API access and optional keys for
+log summarisation. The `args` input accepts any arguments supported by the CLI and defaults to
 `--help`.


### PR DESCRIPTION
what: document tokens required in GitHub Action and link README section
why: help users authenticate composite action
how to test: pre-commit run --files README.md docs/github-action.md && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68aa99d5c170832fa8a005ebc6b77925