### PR TITLE
🐛 fix: validate max-size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ Skip files larger than a given number of bytes:
 f2clipboard files --dir path/to/project --max-size 1000
 ```
 
+`--max-size` must be a positive integer.
+
 Save output to a Markdown file:
 
 ```bash

--- a/f2clipboard/files.py
+++ b/f2clipboard/files.py
@@ -41,6 +41,9 @@ def files_command(
     ),
 ) -> None:
     """Invoke the legacy script to copy selected files to the clipboard."""
+    if max_size is not None and max_size <= 0:
+        raise typer.BadParameter("max-size must be positive")
+
     script_path = Path(__file__).resolve().parent.parent / "f2clipboard.py"
     if not script_path.exists():
         typer.echo("Legacy script not found: f2clipboard.py", err=True)

--- a/tests/test_files_max_size.py
+++ b/tests/test_files_max_size.py
@@ -2,6 +2,8 @@ import importlib.util
 import types
 from pathlib import Path
 
+import pytest
+import typer
 from typer.testing import CliRunner
 
 from f2clipboard import app
@@ -52,6 +54,11 @@ def test_files_command_forwards_max_size(monkeypatch, tmp_path):
         "--max-size",
         "5",
     ]
+
+
+def test_files_command_max_size_must_be_positive():
+    with pytest.raises(typer.BadParameter):
+        files_module.files_command(max_size=0)
 
 
 def test_legacy_main_max_size(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- require positive values for --max-size in files command
- test negative max-size handling
- document positive max-size requirement

## Testing
- `pre-commit run --files f2clipboard/files.py tests/test_files_max_size.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa99bab1e0832f9b24981a4cfa7f83