### PR TITLE
Include plugin paths in count output

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,16 @@ f2clipboard plugins --count --json
 {"count": 1, "plugins": ["jira"]}
 ```
 
+Include plugin paths in the JSON output:
+
+```bash
+f2clipboard plugins --count --paths --json
+```
+
+```json
+{"count": 1, "plugins": {"jira": "/path/to/plugin"}}
+```
+
 Show plugin versions:
 
 ```bash

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -52,7 +52,10 @@ def plugins_command(
     if not _loaded_plugins:
         count_value = 0
         if count and json_output:
-            payload = {"count": count_value, "plugins": {} if versions else []}
+            payload = {
+                "count": count_value,
+                "plugins": {} if (versions or paths) else [],
+            }
             typer.echo(json.dumps(payload))
         elif count:
             typer.echo("0")
@@ -74,7 +77,7 @@ def plugins_command(
     # If filter removes everything, mirror empty behavior again
     if not names:
         if count and json_output:
-            payload = {"count": 0, "plugins": {} if versions else []}
+            payload = {"count": 0, "plugins": {} if (versions or paths) else []}
             typer.echo(json.dumps(payload))
         elif count:
             typer.echo("0")
@@ -92,10 +95,20 @@ def plugins_command(
 
     # Counts should reflect the (possibly filtered) list.
     if count and json_output:
-        if versions:
+        if versions and paths:
+            plugins_data = {
+                name: {
+                    "version": _plugin_versions.get(name, "unknown"),
+                    "path": _plugin_paths.get(name, "unknown"),
+                }
+                for name in names
+            }
+        elif versions:
             plugins_data = {
                 name: _plugin_versions.get(name, "unknown") for name in names
             }
+        elif paths:
+            plugins_data = {name: _plugin_paths.get(name, "unknown") for name in names}
         else:
             plugins_data = names
         typer.echo(json.dumps({"count": len(names), "plugins": plugins_data}))

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -218,6 +218,72 @@ def test_plugins_command_count_versions_json(monkeypatch):
     assert result.stdout.strip() == '{"count": 1, "plugins": {"sample": "unknown"}}'
 
 
+def test_plugins_command_count_paths_json_no_plugins(monkeypatch):
+    importlib.reload(f2clipboard)
+    monkeypatch.setattr(f2clipboard, "entry_points", lambda *a, **k: [])
+    f2clipboard._loaded_plugins = []
+    f2clipboard._plugin_versions = {}
+    f2clipboard._plugin_paths = {}
+    f2clipboard._load_plugins()
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--count", "--paths", "--json"])
+    assert result.exit_code == 0
+    assert result.stdout.strip() == '{"count": 0, "plugins": {}}'
+
+
+def test_plugins_command_count_paths_json(monkeypatch):
+    ep = EntryPoint(
+        name="sample", value="tests.test_plugins:plugin", group="f2clipboard.plugins"
+    )
+
+    def fake_entry_points(*args, **kwargs):
+        if kwargs.get("group") == "f2clipboard.plugins":
+            return [ep]
+        return []
+
+    importlib.reload(f2clipboard)
+    monkeypatch.setattr(f2clipboard, "entry_points", fake_entry_points)
+    f2clipboard._loaded_plugins = []
+    f2clipboard._plugin_versions = {}
+    f2clipboard._plugin_paths = {}
+    f2clipboard._load_plugins()
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["plugins", "--count", "--paths", "--json"])
+    assert result.exit_code == 0
+    path = str(Path(__file__).resolve())
+    expected = json.dumps({"count": 1, "plugins": {"sample": path}})
+    assert result.stdout.strip() == expected
+
+
+def test_plugins_command_count_versions_paths_json(monkeypatch):
+    ep = EntryPoint(
+        name="sample", value="tests.test_plugins:plugin", group="f2clipboard.plugins"
+    )
+
+    def fake_entry_points(*args, **kwargs):
+        if kwargs.get("group") == "f2clipboard.plugins":
+            return [ep]
+        return []
+
+    importlib.reload(f2clipboard)
+    monkeypatch.setattr(f2clipboard, "entry_points", fake_entry_points)
+    f2clipboard._loaded_plugins = []
+    f2clipboard._plugin_versions = {}
+    f2clipboard._plugin_paths = {}
+    f2clipboard._load_plugins()
+    runner = CliRunner()
+    result = runner.invoke(
+        f2clipboard.app,
+        ["plugins", "--count", "--versions", "--paths", "--json"],
+    )
+    assert result.exit_code == 0
+    path = str(Path(__file__).resolve())
+    expected = json.dumps(
+        {"count": 1, "plugins": {"sample": {"version": "unknown", "path": path}}}
+    )
+    assert result.stdout.strip() == expected
+
+
 def test_plugins_command_versions(monkeypatch):
     ep = EntryPoint(
         name="sample", value="tests.test_plugins:plugin", group="f2clipboard.plugins"


### PR DESCRIPTION
## Summary
- support --paths with --count --json to include plugin file paths
- document count output with paths
- test plugin path support

## Testing
- `pre-commit run --files f2clipboard/__init__.py tests/test_plugins.py README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa99bab1e0832f9b24981a4cfa7f83