### PR TITLE
🧪 : register vcr pytest marker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,5 @@
 
 1. Fork and clone the repository.
 2. Run `pre-commit run --files <modified_files>` and `pytest -q` before opening a pull request.
-3. Describe your changes clearly.
+3. Mark tests that record HTTP interactions with `@pytest.mark.vcr`.
+4. Describe your changes clearly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ jira = "f2clipboard.plugins.jira:register"
 
 [tool.pytest.ini_options]
 addopts = "-q"
+markers = [
+    "vcr: mark tests that use pytest-recording",
+]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary
- register vcr pytest marker to silence warning
- document use of `@pytest.mark.vcr`

## Testing
- `pre-commit run --files pyproject.toml CONTRIBUTING.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa99bab1e0832f9b24981a4cfa7f83