### PR TITLE
Handle trailing slashes in ignore patterns

### DIFF
--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -98,7 +98,7 @@ def list_files(
     directory,
     pattern="*",
     include_patterns=None,
-    ignore_patterns=[],
+    ignore_patterns=None,
     max_size=None,
 ):
     """Recursively list files in a directory matching any of the patterns, skipping ignored,
@@ -109,6 +109,10 @@ def list_files(
         for pat in include_patterns:
             patterns.extend(expand_pattern(pat))
 
+    normalized_ignore = (
+        [p.rstrip("/\\") for p in ignore_patterns] if ignore_patterns else []
+    )
+
     for root, dirs, files in os.walk(directory):
         # Skip directories in ignore patterns
         dirs[:] = [
@@ -116,7 +120,7 @@ def list_files(
             for d in dirs
             if not any(
                 fnmatch.fnmatch(os.path.join(root, d), os.path.join(root, pat))
-                for pat in ignore_patterns
+                for pat in normalized_ignore
             )
         ]
 
@@ -126,7 +130,7 @@ def list_files(
             # Skip files that match ignore patterns
             if any(
                 fnmatch.fnmatch(filename, os.path.join(root, pat))
-                for pat in ignore_patterns
+                for pat in normalized_ignore
             ):
                 continue
 

--- a/tests/test_files_exclude.py
+++ b/tests/test_files_exclude.py
@@ -29,6 +29,15 @@ def test_list_files_respects_exclude(tmp_path):
     assert str(tmp_path / "b.py") not in files
 
 
+def test_list_files_skips_directory_with_trailing_slash(tmp_path):
+    ignored = tmp_path / "ignored"
+    ignored.mkdir()
+    (ignored / "file.txt").write_text("data")
+    legacy = _load_legacy_module()
+    files = list(legacy.list_files(str(tmp_path), ignore_patterns=["ignored/"]))
+    assert files == []
+
+
 def test_files_command_forwards_exclude(monkeypatch, tmp_path):
     called = {}
 


### PR DESCRIPTION
## Summary
- normalize ignore patterns to drop trailing slashes
- cover directory exclusion with a test

## Testing
- `pre-commit run --files f2clipboard.py tests/test_files_exclude.py`
- `pytest -q`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68aa99ce2e70832fa6274c7739cbcacf