### PR TITLE
fix empty options in brace pattern expansion

### DIFF
--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -90,6 +90,7 @@ def expand_pattern(pattern):
     options = [
         opt.strip()
         for opt in pattern[pattern.find("{") + 1 : pattern.find("}")].split(",")
+        if opt.strip()
     ]
     return [f"{prefix}{opt}{suffix}" for opt in options]
 

--- a/tests/test_expand_pattern.py
+++ b/tests/test_expand_pattern.py
@@ -14,3 +14,7 @@ def test_expand_pattern_strips_whitespace():
 
 def test_expand_pattern_no_braces():
     assert module.expand_pattern("*.py") == ["*.py"]
+
+
+def test_expand_pattern_ignores_empty_entries():
+    assert module.expand_pattern("*.{py,}") == ["*.py"]


### PR DESCRIPTION
## Summary
- avoid generating empty glob patterns when expanding brace syntax
- add regression test for empty brace options

## Testing
- `pre-commit run --all-files`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa99ce2e70832fa6274c7739cbcacf