### PR TITLE
🩹: replace deprecated pydantic config

### DIFF
--- a/f2clipboard/config.py
+++ b/f2clipboard/config.py
@@ -1,7 +1,7 @@
 """Application settings loaded from environment variables."""
 
 from pydantic import Field
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
@@ -23,6 +23,4 @@ class Settings(BaseSettings):
         description=("Summarise logs larger than this many bytes; set 0 to disable"),
     )
 
-    class Config:
-        env_file = ".env"
-        case_sensitive = False
+    model_config = SettingsConfigDict(env_file=".env", case_sensitive=False)


### PR DESCRIPTION
what: use SettingsConfigDict instead of Config
why: remove Pydantic V2 deprecation warning
how: pre-commit run --files f2clipboard/config.py && pytest -q

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68aa99ce2e70832fa6274c7739cbcacf