### PR TITLE
✨ : – Add check-run links to headings

### DIFF
--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -182,7 +182,10 @@ async def _process_task(url: str, settings: Settings) -> str:
                 )
             else:
                 rendered = f"```text\n{log_text}\n```"
-            sections.append(f"### {run['name']}\n\n{rendered}")
+            name = str(run.get("name", "Unnamed check"))
+            html_url = run.get("html_url")
+            heading = f"### [{name}]({html_url})" if html_url else f"### {name}"
+            sections.append(f"{heading}\n\n{rendered}")
 
     return "\n\n".join(sections) or "No failing checks"
 


### PR DESCRIPTION
✨ : – Add check-run links to headings

what: hyperlink failing check headings to GitHub runs.
why: deliver documented promise of job links in Markdown.
how to test: pre-commit run --files \
  f2clipboard/codex_task.py tests/test_codex_task.py
how to test: pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dcc23524b4832f926bdae350f4aff9