### PR TITLE
✨ : – Allow disabling log summarisation with zero threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ f2clipboard codex-task https://chatgpt.com/codex/tasks/task_123 --log-size-thres
 ```
 
 The default threshold can also be set via the ``LOG_SIZE_THRESHOLD`` environment variable in
-your ``.env`` file.
+your ``.env`` file. Set the threshold to ``0`` to disable summarisation entirely.
 
 Generate a prompt that reads a shared chat transcript and implements any code or configuration
 changes it mentions:

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -110,7 +110,7 @@ def test_process_task_redacts(monkeypatch):
     monkeypatch.setattr("f2clipboard.codex_task.summarise_log", fake_summary)
 
     settings = Settings()
-    settings.log_size_threshold = 0
+    settings.log_size_threshold = 1
     result = asyncio.run(_process_task("http://task", settings))
     assert "abcdef123456" not in result  # pragma: allowlist secret
     assert "SUMMARY" in result


### PR DESCRIPTION
what: treat LOG_SIZE_THRESHOLD=0 as disabling summarisation and document it.
why: match Settings description that promised zero would turn summaries off.
how to test:
- python -m pre_commit run --files f2clipboard/codex_task.py tests/test_codex_task.py tests/test_secret.py README.md
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dcd42f8c64832f94008f280ad3b148