### PR TITLE
✨ : – respect target .gitignore in files workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ f2clipboard files --dir path/to/project
 
 The command skips common binary and image files (for example, `.jpg`, `.png`, `.heic`) so the
 output contains only text-friendly content. It also honours patterns from `.gitignore`,
-stripping any inline `#` comments.
+stripping any inline `#` comments. The `.gitignore` file is resolved relative to `--dir`, so you
+can run the command from outside the project directory.
 
 Exclude glob patterns by repeating `--exclude`:
 

--- a/f2clipboard.py
+++ b/f2clipboard.py
@@ -304,7 +304,8 @@ def main(argv=None):
     args = parser.parse_args(argv)
     directory = args.dir
     pattern = args.pattern
-    ignore_patterns = parse_gitignore()
+    gitignore_path = os.path.join(directory, ".gitignore")
+    ignore_patterns = parse_gitignore(gitignore_path)
     if args.exclude:
         ignore_patterns.extend(args.exclude)
     files = list(

--- a/tests/test_files_exclude.py
+++ b/tests/test_files_exclude.py
@@ -102,3 +102,22 @@ def test_legacy_main_uses_exclude(monkeypatch, tmp_path):
 
     assert "b.py" not in copied["data"]
     assert "a.py" in copied["data"]
+
+
+def test_legacy_main_reads_gitignore_from_target(monkeypatch, tmp_path, capsys):
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".gitignore").write_text("ignored.py\n")
+    (project / "kept.py").write_text("keep")
+    (project / "ignored.py").write_text("skip")
+    legacy = _load_legacy_module()
+
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    legacy.main(["--dir", str(project), "--pattern", "*.py", "--all", "--dry-run"])
+
+    out = capsys.readouterr().out
+    assert "kept.py" in out
+    assert "ignored.py" not in out


### PR DESCRIPTION
what: load .gitignore from target dir when running the files workflow
why: README promises gitignore support even from other directories
how to test: pre-commit run --files README.md f2clipboard.py
  tests/test_files_exclude.py && pytest -q
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68dcd42f8c64832f94008f280ad3b148