### PR TITLE
Wrap Codex summaries in fenced blocks

### DIFF
--- a/f2clipboard/codex_task.py
+++ b/f2clipboard/codex_task.py
@@ -192,7 +192,8 @@ async def _process_task(url: str, settings: Settings) -> str:
                 summary = await summarise_log(log_text, settings)
                 snippet = "\n".join(log_text.splitlines()[:SUMMARY_HEAD_LINES])
                 rendered = (
-                    f"{summary}\n\n<details>\n<summary>First {SUMMARY_HEAD_LINES} lines</summary>\n\n"
+                    f"```text\n{summary}\n```\n\n"
+                    f"<details>\n<summary>First {SUMMARY_HEAD_LINES} lines</summary>\n\n"
                     f"```text\n{snippet}\n```\n</details>"
                 )
             else:

--- a/tests/test_codex_task.py
+++ b/tests/test_codex_task.py
@@ -208,7 +208,8 @@ def test_process_task_summarises_large_log(monkeypatch):
     settings.log_size_threshold = 100
     result = asyncio.run(_process_task("http://task", settings))
     assert "### [Job](https://github.com/o/r/actions/runs/1)" in result
-    assert "SUMMARY\n\n<details>" in result
+    assert "```text\nSUMMARY\n```" in result
+    assert "<details>" in result
     assert "line 1" in result
     assert f"line {SUMMARY_HEAD_LINES}" in result
     assert f"line {SUMMARY_HEAD_LINES + 1}" not in result


### PR DESCRIPTION
what: fence oversized Codex log summaries and adjust the unit test.
why: README promises each failing check includes a fenced log or summary block.
how to test: pre-commit run --files f2clipboard/codex_task.py tests/test_codex_task.py
how to test: pytest -q
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68de05b9eb38832fb0d6f3a0893444ef