### PR TITLE
✨ : – Ensure chat2prompt handles more block-level HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ The prompt is copied to your clipboard by default. To skip copying, use ``--no-c
 f2clipboard chat2prompt https://chatgpt.com/share/abcdefg --no-clipboard
 ```
 
-HTML tags are stripped and block-level elements become newlines to preserve chat formatting.
-Unordered lists are converted to `-` bullets and ordered lists become numbered items,
-honouring any HTML `start` attributes.
+HTML tags are stripped and block-level elements (including sectioning tags such as
+`<section>`, `<article>`, `<aside>`, and preformatted blocks like `<pre>` or `<blockquote>`)
+become newlines to preserve chat formatting. Unordered lists are converted to `-` bullets and
+ordered lists become numbered items, honouring any HTML `start` attributes.
 
 Specify a different platform with ``--platform``:
 

--- a/f2clipboard/chat2prompt.py
+++ b/f2clipboard/chat2prompt.py
@@ -9,6 +9,15 @@ import clipboard
 import httpx
 import typer
 
+_BLOCK_LEVEL_PATTERN = re.compile(
+    r"</?(?:"
+    r"br|p|div|section|article|header|footer|nav|main|aside|pre|blockquote|"
+    r"figure|figcaption|table|thead|tbody|tfoot|tr|dl|fieldset|address|form|hr|"
+    r"h[1-6]|ul|ol)"
+    r"[^>]*>",
+    flags=re.IGNORECASE,
+)
+
 
 def _extract_text(html_text: str) -> str:
     """Return plain text from HTML, preserving line breaks and bullet points."""
@@ -32,9 +41,7 @@ def _extract_text(html_text: str) -> str:
     )
     html_text = re.sub(r"<li[^>]*>", "\n- ", html_text, flags=re.IGNORECASE)
     html_text = re.sub(r"</li[^>]*>", "\n", html_text, flags=re.IGNORECASE)
-    html_text = re.sub(
-        r"</?(?:br|p|div|h[1-6])[^>]*>", "\n", html_text, flags=re.IGNORECASE
-    )
+    html_text = _BLOCK_LEVEL_PATTERN.sub("\n", html_text)
     text = re.sub(r"<[^>]+>", "", html_text)
     text = html.unescape(text)
     lines = [line.strip() for line in text.splitlines()]

--- a/tests/test_chat2prompt.py
+++ b/tests/test_chat2prompt.py
@@ -39,6 +39,16 @@ def test_extract_text_respects_ordered_list_start():
     assert _extract_text(html) == "3. First\n4. Second"
 
 
+def test_extract_text_handles_additional_block_tags():
+    html = "<section>Alpha</section><article>Beta</article><aside>Gamma</aside>"
+    assert _extract_text(html) == "Alpha\nBeta\nGamma"
+
+
+def test_extract_text_handles_preformatted_blocks():
+    html = "<pre>line1\nline2</pre>"
+    assert _extract_text(html) == "line1\nline2"
+
+
 def test_chat2prompt_command_copies_prompt(monkeypatch, capsys):
     def fake_fetch(url: str, timeout: float) -> str:
         assert url == "http://chat"


### PR DESCRIPTION
what: expand chat2prompt newline handling for additional block-level tags and update tests/docs.
why: README promises block-level elements map to newlines but sectioning/preformatted tags were collapsing together.
how to test: pre-commit run --files f2clipboard/chat2prompt.py tests/test_chat2prompt.py README.md && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de05b9eb38832fb0d6f3a0893444ef