### PR TITLE
Add merge-checks CLI helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,19 @@ Check the installed version:
 f2clipboard --version
 ```
 
+### Merge conflict helpers
+
+Run the standard checks after resolving conflicts:
+
+```bash
+f2clipboard merge-checks
+```
+
+The command looks for modified files in the current repository, runs
+`pre-commit run --files` for those paths, and then executes `pytest -q`. Use
+`--file` to pass an explicit list of files or `--repo` to point at a different
+working tree.
+
 ## GitHub Action
 
 Run `f2clipboard` inside GitHub Actions using the bundled composite action:

--- a/docs/merge-conflict-roadmap.md
+++ b/docs/merge-conflict-roadmap.md
@@ -7,12 +7,12 @@ This checklist captures the workflow for resolving merge conflicts in pull reque
   - [ ] `git checkout pr-merge`
   - [ ] Determine the base branch (`main` or from PR metadata)
 - [ ] Attempt automatic resolutions
-  - [ ] Strategy A – merge with `-X ours` and run checks
-    - [ ] `pre-commit run --files <modified_files>`
-    - [ ] `pytest -q`
-  - [ ] Strategy B – merge with `-X theirs` and run checks
-    - [ ] `pre-commit run --files <modified_files>`
-    - [ ] `pytest -q`
+- [ ] Strategy A – merge with `-X ours` and run checks
+  - [x] `pre-commit run --files <modified_files>` (use `f2clipboard merge-checks`)
+  - [x] `pytest -q` (covered by `f2clipboard merge-checks`)
+- [ ] Strategy B – merge with `-X theirs` and run checks
+  - [x] `pre-commit run --files <modified_files>` (use `f2clipboard merge-checks`)
+  - [x] `pytest -q` (covered by `f2clipboard merge-checks`)
 - [ ] If both strategies fail
   - [ ] Collect conflicting hunks: `git --no-pager diff --name-only --diff-filter=U`
   - [ ] Use the Codex merge-conflicts prompt to generate a patch

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -10,6 +10,7 @@ from typer import Typer
 from .chat2prompt import chat2prompt_command
 from .codex_task import codex_task_command
 from .files import files_command
+from .merge_checks import merge_checks_command
 
 try:
     __version__ = version("f2clipboard")
@@ -20,6 +21,7 @@ app = Typer(add_completion=False, help="Flows \u2192 clipboard automation CLI")
 app.command("codex-task")(codex_task_command)
 app.command("chat2prompt")(chat2prompt_command)
 app.command("files")(files_command)
+app.command("merge-checks")(merge_checks_command)
 
 _loaded_plugins: list[str] = []
 _plugin_versions: dict[str, str] = {}

--- a/f2clipboard/merge_checks.py
+++ b/f2clipboard/merge_checks.py
@@ -1,0 +1,107 @@
+"""Utilities for running merge validation checks."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+import typer
+
+
+def _parse_git_status(output: str) -> list[str]:
+    """Return modified file paths parsed from ``git status --porcelain`` output."""
+
+    files: list[str] = []
+    for line in output.splitlines():
+        if not line:
+            continue
+        status = line[:2]
+        path = line[3:].strip()
+        if not path:
+            continue
+        if "->" in path:
+            path = path.split("->", 1)[1].strip()
+        if "D" in status:
+            continue
+        files.append(path)
+    return files
+
+
+def _collect_modified_files(repo: Path) -> list[str]:
+    """Return tracked files with modifications inside *repo*."""
+
+    proc = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if proc.returncode != 0:
+        message = proc.stderr.strip() or "git status failed"
+        raise RuntimeError(message)
+    return _parse_git_status(proc.stdout)
+
+
+def _run_command(args: Iterable[str], cwd: Path) -> int:
+    """Run a subprocess returning its exit code."""
+
+    result = subprocess.run(list(args), cwd=cwd)
+    return result.returncode
+
+
+def merge_checks_command(
+    files: list[Path] | None = typer.Option(
+        None,
+        "--file",
+        "-f",
+        help="Explicit file paths to run pre-commit on.",
+        show_default=False,
+    ),
+    repo: Path = typer.Option(
+        Path("."),
+        "--repo",
+        help="Repository root containing the merge worktree.",
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        resolve_path=True,
+    ),
+) -> None:
+    """Run ``pre-commit`` and ``pytest`` to validate a merge."""
+
+    repo = repo.resolve()
+    target_files: list[str]
+    if files:
+        target_files = []
+        for path in files:
+            resolved = path if path.is_absolute() else (repo / path)
+            resolved = resolved.resolve()
+            try:
+                target_files.append(str(resolved.relative_to(repo)))
+            except ValueError:
+                target_files.append(str(resolved))
+    else:
+        try:
+            target_files = _collect_modified_files(repo)
+        except RuntimeError as exc:
+            typer.echo(f"Failed to determine modified files: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+
+    if target_files:
+        typer.echo(
+            f"Running pre-commit on {len(target_files)} file(s)…",
+        )
+        exit_code = _run_command(["pre-commit", "run", "--files", *target_files], repo)
+        if exit_code != 0:
+            raise typer.Exit(code=exit_code)
+    else:
+        typer.echo("No modified files detected; skipping pre-commit.")
+
+    typer.echo("Running pytest -q…")
+    exit_code = _run_command(["pytest", "-q"], repo)
+    if exit_code != 0:
+        raise typer.Exit(code=exit_code)
+
+    typer.echo("Checks completed successfully.")

--- a/tests/test_merge_checks.py
+++ b/tests/test_merge_checks.py
@@ -1,0 +1,100 @@
+import subprocess
+
+import pytest
+from typer.testing import CliRunner
+
+import f2clipboard
+
+
+def test_merge_checks_runs_on_modified_files(monkeypatch, tmp_path):
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=" M app.py\n?? new.txt\n",
+                stderr="",
+            )
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("f2clipboard.merge_checks.subprocess.run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["merge-checks", "--repo", str(tmp_path)])
+    assert result.exit_code == 0
+    assert calls[0][:3] == ["pre-commit", "run", "--files"]
+    assert calls[0][3:] == ["app.py", "new.txt"]
+    assert calls[1] == ["pytest", "-q"]
+
+
+def test_merge_checks_respects_explicit_files(monkeypatch, tmp_path):
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "status"]:
+            pytest.fail("git status should not be called when files are provided")
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("f2clipboard.merge_checks.subprocess.run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        f2clipboard.app,
+        ["merge-checks", "--repo", str(tmp_path), "--file", "a.py", "--file", "b.py"],
+    )
+    assert result.exit_code == 0
+    assert calls[0][:3] == ["pre-commit", "run", "--files"]
+    assert calls[0][3:] == ["a.py", "b.py"]
+    assert calls[1] == ["pytest", "-q"]
+
+
+def test_merge_checks_skips_pre_commit_without_files(monkeypatch, tmp_path):
+    commands: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr("f2clipboard.merge_checks.subprocess.run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["merge-checks", "--repo", str(tmp_path)])
+    assert result.exit_code == 0
+    assert commands == [["pytest", "-q"]]
+
+
+def test_merge_checks_exits_on_pre_commit_failure(monkeypatch, tmp_path):
+    commands: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "status"]:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=" M main.py\n",
+                stderr="",
+            )
+        if cmd[:2] == ["pre-commit", "run"]:
+            commands.append(cmd)
+            return subprocess.CompletedProcess(cmd, 3)
+        pytest.fail("pytest should not run when pre-commit fails")
+
+    monkeypatch.setattr("f2clipboard.merge_checks.subprocess.run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(f2clipboard.app, ["merge-checks", "--repo", str(tmp_path)])
+    assert result.exit_code == 3
+    assert commands[0][:3] == ["pre-commit", "run", "--files"]
+
+
+def test_parse_git_status_handles_rename_and_deletion():
+    from f2clipboard.merge_checks import _parse_git_status
+
+    output = "R  old.py -> new.py\nD  removed.py\n?? added.py\n"
+    assert _parse_git_status(output) == ["new.py", "added.py"]


### PR DESCRIPTION
✅ : –
what: add merge-checks CLI helper running pre-commit/pytest
why: cover merge-conflict checklist steps for verification
how to test: pre-commit run --files README.md
  docs/merge-conflict-roadmap.md f2clipboard/__init__.py
  f2clipboard/merge_checks.py tests/test_merge_checks.py
how to test: pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de05b9eb38832fb0d6f3a0893444ef