### PR TITLE
Add merge-resolve command for automatic conflict resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,17 @@ f2clipboard --version
 
 ### Merge conflict helpers
 
+Try automatic merge strategies when rebasing a PR branch:
+
+```bash
+f2clipboard merge-resolve --base origin/main --strategy both
+```
+
+The command ensures the working tree is clean, attempts the requested merge
+strategy (or both), and by default runs `f2clipboard merge-checks` after a
+successful merge. Pass `--no-run-checks` to skip automated validation or use
+`--strategy ours`/`--strategy theirs` to attempt a single strategy.
+
 Run the standard checks after resolving conflicts:
 
 ```bash

--- a/docs/merge-conflict-roadmap.md
+++ b/docs/merge-conflict-roadmap.md
@@ -6,11 +6,11 @@ This checklist captures the workflow for resolving merge conflicts in pull reque
   - [ ] `git fetch origin pull/<PR_NUMBER>/head:pr-merge`
   - [ ] `git checkout pr-merge`
   - [ ] Determine the base branch (`main` or from PR metadata)
-- [ ] Attempt automatic resolutions
-- [ ] Strategy A – merge with `-X ours` and run checks
+- [x] Attempt automatic resolutions (use `f2clipboard merge-resolve`)
+- [x] Strategy A – merge with `-X ours` and run checks (`f2clipboard merge-resolve --strategy ours`)
   - [x] `pre-commit run --files <modified_files>` (use `f2clipboard merge-checks`)
   - [x] `pytest -q` (covered by `f2clipboard merge-checks`)
-- [ ] Strategy B – merge with `-X theirs` and run checks
+- [x] Strategy B – merge with `-X theirs` and run checks (`f2clipboard merge-resolve --strategy theirs`)
   - [x] `pre-commit run --files <modified_files>` (use `f2clipboard merge-checks`)
   - [x] `pytest -q` (covered by `f2clipboard merge-checks`)
 - [ ] If both strategies fail

--- a/f2clipboard/__init__.py
+++ b/f2clipboard/__init__.py
@@ -11,6 +11,7 @@ from .chat2prompt import chat2prompt_command
 from .codex_task import codex_task_command
 from .files import files_command
 from .merge_checks import merge_checks_command
+from .merge_resolve import merge_resolve_command
 
 try:
     __version__ = version("f2clipboard")
@@ -22,6 +23,7 @@ app.command("codex-task")(codex_task_command)
 app.command("chat2prompt")(chat2prompt_command)
 app.command("files")(files_command)
 app.command("merge-checks")(merge_checks_command)
+app.command("merge-resolve")(merge_resolve_command)
 
 _loaded_plugins: list[str] = []
 _plugin_versions: dict[str, str] = {}

--- a/f2clipboard/merge_resolve.py
+++ b/f2clipboard/merge_resolve.py
@@ -1,0 +1,141 @@
+"""Automate merge conflict resolution attempts."""
+
+from __future__ import annotations
+
+import subprocess
+from enum import Enum
+from pathlib import Path
+
+import typer
+
+from .merge_checks import merge_checks_command
+
+
+class MergeStrategy(str, Enum):
+    """Supported automatic merge strategies."""
+
+    ours = "ours"
+    theirs = "theirs"
+    both = "both"
+
+
+def _git_status(repo: Path) -> subprocess.CompletedProcess[str]:
+    """Return ``git status --porcelain`` output for *repo*."""
+
+    return subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _ensure_clean_worktree(repo: Path) -> None:
+    """Abort if the repository has uncommitted changes or an active merge."""
+
+    merge_head = repo / ".git" / "MERGE_HEAD"
+    if merge_head.exists():
+        typer.echo(
+            "A merge is already in progress. Complete or abort it before rerunning.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    status = _git_status(repo)
+    if status.returncode != 0:
+        message = status.stderr.strip() or "git status failed"
+        typer.echo(message, err=True)
+        raise typer.Exit(code=status.returncode or 1)
+    if status.stdout.strip():
+        typer.echo(
+            "Repository has uncommitted changes. Commit or stash them before running merge-resolve.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+
+def _attempt_merge(repo: Path, base: str, strategy: MergeStrategy) -> bool:
+    """Try merging *base* into *repo* using *strategy*."""
+
+    typer.echo(f"Attempting merge with strategy '{strategy.value}' from {base}…")
+    result = subprocess.run(
+        ["git", "merge", "--no-commit", "-X", strategy.value, base],
+        cwd=repo,
+    )
+    if result.returncode == 0:
+        return True
+
+    typer.echo(
+        f"Merge with strategy '{strategy.value}' failed (exit code {result.returncode}).",
+        err=True,
+    )
+    abort = subprocess.run(["git", "merge", "--abort"], cwd=repo)
+    if abort.returncode != 0:
+        typer.echo(
+            "Failed to abort merge automatically; resolve the repository state manually.",
+            err=True,
+        )
+        raise typer.Exit(code=abort.returncode or 1)
+    return False
+
+
+def merge_resolve_command(
+    base: str = typer.Option(
+        "origin/main", "--base", "-b", help="Base branch to merge from."
+    ),
+    strategy: MergeStrategy = typer.Option(
+        MergeStrategy.ours,
+        "--strategy",
+        "-s",
+        help="Merge strategy to attempt (ours, theirs or both).",
+    ),
+    repo: Path = typer.Option(
+        Path("."),
+        "--repo",
+        help="Repository containing the PR branch.",
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        resolve_path=True,
+    ),
+    run_checks: bool = typer.Option(
+        True,
+        "--run-checks/--no-run-checks",
+        help="Run `f2clipboard merge-checks` after a successful merge.",
+    ),
+) -> None:
+    """Attempt automatic merge conflict resolution strategies."""
+
+    repo = repo.resolve()
+    _ensure_clean_worktree(repo)
+
+    strategies: list[MergeStrategy]
+    if strategy is MergeStrategy.both:
+        strategies = [MergeStrategy.ours, MergeStrategy.theirs]
+    else:
+        strategies = [strategy]
+
+    succeeded: MergeStrategy | None = None
+    for current in strategies:
+        if _attempt_merge(repo, base, current):
+            succeeded = current
+            break
+
+    if succeeded is None:
+        typer.echo(
+            "Automatic merge strategies failed. Manual intervention required.", err=True
+        )
+        raise typer.Exit(code=1)
+
+    typer.echo(f"Merge completed using strategy '{succeeded.value}'.")
+    typer.echo(
+        "Review the changes, resolve any remaining issues and commit when ready."
+    )
+
+    if run_checks:
+        merge_checks_command(files=None, repo=repo)
+    else:
+        typer.echo(
+            "Run `f2clipboard merge-checks` to validate the merge when convenient."
+        )

--- a/tests/test_merge_resolve.py
+++ b/tests/test_merge_resolve.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+import f2clipboard
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _prepare_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    (repo / "file.txt").write_text("initial\n", encoding="utf-8")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-m", "initial")
+    _git(repo, "branch", "-M", "main")
+    return repo
+
+
+def _create_conflict_repo(tmp_path: Path) -> Path:
+    repo = _prepare_repo(tmp_path)
+    _git(repo, "checkout", "-b", "feature")
+    (repo / "file.txt").write_text("feature\n", encoding="utf-8")
+    _git(repo, "commit", "-am", "feature change")
+    _git(repo, "checkout", "main")
+    (repo / "file.txt").write_text("main\n", encoding="utf-8")
+    _git(repo, "commit", "-am", "main change")
+    _git(repo, "checkout", "feature")
+    return repo
+
+
+def test_merge_resolve_prefers_ours(tmp_path: Path) -> None:
+    repo = _create_conflict_repo(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        f2clipboard.app,
+        [
+            "merge-resolve",
+            "--repo",
+            str(repo),
+            "--base",
+            "main",
+            "--strategy",
+            "ours",
+            "--no-run-checks",
+        ],
+    )
+    assert result.exit_code == 0
+    assert (repo / "file.txt").read_text(encoding="utf-8") == "feature\n"
+
+
+def test_merge_resolve_prefers_theirs(tmp_path: Path) -> None:
+    repo = _create_conflict_repo(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        f2clipboard.app,
+        [
+            "merge-resolve",
+            "--repo",
+            str(repo),
+            "--base",
+            "main",
+            "--strategy",
+            "theirs",
+            "--no-run-checks",
+        ],
+    )
+    assert result.exit_code == 0
+    assert (repo / "file.txt").read_text(encoding="utf-8") == "main\n"
+
+
+def test_merge_resolve_requires_clean_worktree(tmp_path: Path) -> None:
+    repo = _create_conflict_repo(tmp_path)
+    (repo / "untracked.txt").write_text("dirty", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(
+        f2clipboard.app,
+        ["merge-resolve", "--repo", str(repo), "--base", "main", "--strategy", "ours"],
+    )
+    assert result.exit_code != 0
+    output = result.stdout + result.stderr
+    assert "uncommitted changes" in output
+
+
+def test_merge_resolve_attempts_both_strategies(monkeypatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        if cmd[:3] == ["git", "status", "--porcelain"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[:5] == ["git", "merge", "--no-commit", "-X", "ours"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="conflict")
+        if cmd == ["git", "merge", "--abort"]:
+            return subprocess.CompletedProcess(cmd, 0)
+        if cmd[:5] == ["git", "merge", "--no-commit", "-X", "theirs"]:
+            return subprocess.CompletedProcess(cmd, 0)
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr("f2clipboard.merge_resolve.subprocess.run", fake_run)
+
+    runner = CliRunner()
+    repo = tmp_path
+    result = runner.invoke(
+        f2clipboard.app,
+        [
+            "merge-resolve",
+            "--repo",
+            str(repo),
+            "--base",
+            "main",
+            "--strategy",
+            "both",
+            "--no-run-checks",
+        ],
+    )
+    assert result.exit_code == 0
+    assert any(
+        call[:6] == ["git", "merge", "--no-commit", "-X", "ours", "main"]
+        for call in calls
+    )
+    assert any(
+        call[:6] == ["git", "merge", "--no-commit", "-X", "theirs", "main"]
+        for call in calls
+    )
+
+
+def test_merge_resolve_runs_checks(monkeypatch, tmp_path: Path) -> None:
+    repo = _create_conflict_repo(tmp_path)
+    called: dict[str, Path] = {}
+
+    def fake_merge_checks(*, files, repo: Path) -> None:
+        called["repo"] = repo
+
+    monkeypatch.setattr(
+        "f2clipboard.merge_resolve.merge_checks_command", fake_merge_checks
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        f2clipboard.app,
+        ["merge-resolve", "--repo", str(repo), "--base", "main", "--strategy", "ours"],
+    )
+    assert result.exit_code == 0
+    assert called["repo"] == repo


### PR DESCRIPTION
## Summary
- add a `merge-resolve` CLI command that tries ours/theirs merge strategies and optionally runs checks
- document the new workflow in the README and roadmap checklist
- exercise the command with end-to-end git repo tests and strategy fallbacks

## Testing
- pre-commit run --files f2clipboard/merge_resolve.py f2clipboard/__init__.py README.md docs/merge-conflict-roadmap.md tests/test_merge_resolve.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dec0357c8c832f997950d0c4543409