### PR TITLE
Add Codex prompt fallback for merge-resolve failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ strategy (or both), and by default runs `f2clipboard merge-checks` after a
 successful merge. Pass `--no-run-checks` to skip automated validation or use
 `--strategy ours`/`--strategy theirs` to attempt a single strategy.
 
+If neither strategy succeeds, the command captures the conflicting file list and
+unmerged diff hunks, then prints a Codex-ready prompt so you can request a
+patch before rerunning `f2clipboard merge-checks`.
+
 Run the standard checks after resolving conflicts:
 
 ```bash

--- a/docs/merge-conflict-roadmap.md
+++ b/docs/merge-conflict-roadmap.md
@@ -14,7 +14,7 @@ This checklist captures the workflow for resolving merge conflicts in pull reque
   - [x] `pre-commit run --files <modified_files>` (use `f2clipboard merge-checks`)
   - [x] `pytest -q` (covered by `f2clipboard merge-checks`)
 - [ ] If both strategies fail
-  - [ ] Collect conflicting hunks: `git --no-pager diff --name-only --diff-filter=U`
-  - [ ] Use the Codex merge-conflicts prompt to generate a patch
+  - [x] Collect conflicting hunks: `git --no-pager diff --name-only --diff-filter=U`
+  - [x] Use the Codex merge-conflicts prompt to generate a patch (emitted by `merge-resolve`)
   - [ ] Apply the patch and rerun checks
 - [ ] Post a PR comment summarizing the outcome (strategy used or need for manual review)

--- a/f2clipboard/merge_resolve.py
+++ b/f2clipboard/merge_resolve.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import subprocess
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
+from typing import Callable, Optional
 
 import typer
 
@@ -17,6 +19,14 @@ class MergeStrategy(str, Enum):
     ours = "ours"
     theirs = "theirs"
     both = "both"
+
+
+@dataclass
+class ConflictDetails:
+    """Captured information about unresolved merge conflicts."""
+
+    files: list[str]
+    diff: str
 
 
 def _git_status(repo: Path) -> subprocess.CompletedProcess[str]:
@@ -55,7 +65,12 @@ def _ensure_clean_worktree(repo: Path) -> None:
         raise typer.Exit(code=1)
 
 
-def _attempt_merge(repo: Path, base: str, strategy: MergeStrategy) -> bool:
+def _attempt_merge(
+    repo: Path,
+    base: str,
+    strategy: MergeStrategy,
+    on_failure: Optional[Callable[[Path], None]] = None,
+) -> bool:
     """Try merging *base* into *repo* using *strategy*."""
 
     typer.echo(f"Attempting merge with strategy '{strategy.value}' from {base}…")
@@ -70,6 +85,8 @@ def _attempt_merge(repo: Path, base: str, strategy: MergeStrategy) -> bool:
         f"Merge with strategy '{strategy.value}' failed (exit code {result.returncode}).",
         err=True,
     )
+    if on_failure is not None:
+        on_failure(repo)
     abort = subprocess.run(["git", "merge", "--abort"], cwd=repo)
     if abort.returncode != 0:
         typer.echo(
@@ -78,6 +95,98 @@ def _attempt_merge(repo: Path, base: str, strategy: MergeStrategy) -> bool:
         )
         raise typer.Exit(code=abort.returncode or 1)
     return False
+
+
+def _collect_conflict_details(repo: Path) -> ConflictDetails:
+    """Return conflicting file names and diff hunks for the current merge state."""
+
+    files_proc = subprocess.run(
+        [
+            "git",
+            "--no-pager",
+            "diff",
+            "--name-only",
+            "--diff-filter=U",
+        ],
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    files: list[str] = []
+    if files_proc.returncode == 0:
+        files = [
+            line.strip() for line in files_proc.stdout.splitlines() if line.strip()
+        ]
+    else:
+        message = files_proc.stderr.strip() or "unable to list conflicting files"
+        typer.echo(f"Warning: {message}", err=True)
+
+    diff_proc = subprocess.run(
+        ["git", "--no-pager", "diff", "--diff-filter=U"],
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    diff = ""
+    if diff_proc.returncode == 0:
+        diff = diff_proc.stdout.strip()
+    else:
+        message = diff_proc.stderr.strip() or "unable to capture conflict diff"
+        typer.echo(f"Warning: {message}", err=True)
+
+    return ConflictDetails(files=files, diff=diff)
+
+
+def _render_conflict_prompt(conflicts: ConflictDetails, base: str) -> None:
+    """Display guidance and a Codex-ready prompt for manual conflict resolution."""
+
+    if conflicts.files:
+        typer.echo("Conflicting files:")
+        for path in conflicts.files:
+            typer.echo(f"- {path}")
+    else:
+        typer.echo("Conflicting files could not be determined.")
+
+    typer.echo("")
+    typer.echo("Codex merge-conflicts prompt:")
+    typer.echo("")
+    lines = [
+        "SYSTEM:",
+        "You are an automated assistant that resolves Git merge conflicts for the f2clipboard project.",
+        "",
+        "USER:",
+        (
+            "The merge of "
+            f"{base} "
+            "into the current branch produced conflicts. Resolve them and return a patch that applies cleanly."
+        ),
+        "Keep unrelated files unchanged.",
+    ]
+    if conflicts.files:
+        lines.append("")
+        lines.append("Conflicting files:")
+        lines.extend(f"- {name}" for name in conflicts.files)
+    lines.extend(
+        [
+            "",
+            "CONTEXT:",
+        ]
+    )
+    if conflicts.diff:
+        lines.append("```diff")
+        lines.append(conflicts.diff)
+        lines.append("```")
+    else:
+        lines.append("(Conflict diff unavailable)")
+    lines.extend(
+        [
+            "",
+            "After applying the generated patch, run `f2clipboard merge-checks` to verify the result.",
+        ]
+    )
+    typer.echo("\n".join(lines))
 
 
 def merge_resolve_command(
@@ -116,9 +225,16 @@ def merge_resolve_command(
     else:
         strategies = [strategy]
 
-    succeeded: MergeStrategy | None = None
+    conflict_details: Optional[ConflictDetails] = None
+
+    def _capture_conflicts(_: Path) -> None:
+        nonlocal conflict_details
+        conflict_details = _collect_conflict_details(repo)
+
+    succeeded: Optional[MergeStrategy] = None
     for current in strategies:
-        if _attempt_merge(repo, base, current):
+        if _attempt_merge(repo, base, current, on_failure=_capture_conflicts):
+            conflict_details = None
             succeeded = current
             break
 
@@ -126,6 +242,13 @@ def merge_resolve_command(
         typer.echo(
             "Automatic merge strategies failed. Manual intervention required.", err=True
         )
+        typer.echo("")
+        if conflict_details is not None:
+            _render_conflict_prompt(conflict_details, base)
+        else:
+            typer.echo(
+                "No conflict details were captured. Retry the merge manually for more context."
+            )
         raise typer.Exit(code=1)
 
     typer.echo(f"Merge completed using strategy '{succeeded.value}'.")


### PR DESCRIPTION
## Summary
- capture conflicting files and diff hunks when merge-resolve strategies fail, then emit a Codex-ready prompt
- document the new fallback flow in the README and mark the roadmap checklist accordingly
- extend merge-resolve tests to cover the prompt output and diff collection callbacks

## Testing
- pre-commit run --files README.md docs/merge-conflict-roadmap.md f2clipboard/merge_resolve.py tests/test_merge_resolve.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df7d4f5770832f97446303f0ba13e7