### PR TITLE
Add merge-resolve --pr flag to fetch and checkout PR branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,16 +243,19 @@ f2clipboard --version
 
 ### Merge conflict helpers
 
-Try automatic merge strategies when rebasing a PR branch:
+Fetch a GitHub pull request and try automatic merge strategies:
 
 ```bash
-f2clipboard merge-resolve --base origin/main --strategy both
+f2clipboard merge-resolve --pr 123 --strategy both
 ```
 
-The command ensures the working tree is clean, attempts the requested merge
-strategy (or both), and by default runs `f2clipboard merge-checks` after a
-successful merge. Pass `--no-run-checks` to skip automated validation or use
-`--strategy ours`/`--strategy theirs` to attempt a single strategy.
+The command fetches the PR's head (`pull/<number>/head`), checks it out into a
+local `pr-<number>` branch, looks up the base branch from the GitHub API, and
+then attempts the requested merge strategy (or both). It also ensures the
+working tree is clean and by default runs `f2clipboard merge-checks` after a
+successful merge. Pass `--no-run-checks` to skip automated validation, use
+`--strategy ours`/`--strategy theirs` to attempt a single strategy, or override
+the merge base with `--base`.
 
 Run the standard checks after resolving conflicts:
 

--- a/docs/merge-conflict-roadmap.md
+++ b/docs/merge-conflict-roadmap.md
@@ -2,10 +2,10 @@
 
 This checklist captures the workflow for resolving merge conflicts in pull requests.
 
-- [ ] Fetch PR metadata and check out the PR branch
-  - [ ] `git fetch origin pull/<PR_NUMBER>/head:pr-merge`
-  - [ ] `git checkout pr-merge`
-  - [ ] Determine the base branch (`main` or from PR metadata)
+- [x] Fetch PR metadata and check out the PR branch (use `f2clipboard merge-resolve --pr`)
+  - [x] Fetch the PR head with `git fetch origin pull/<PR_NUMBER>/head:pr-<PR_NUMBER>`
+  - [x] Check it out into a local `pr-<PR_NUMBER>` branch
+  - [x] Determine the base branch from PR metadata (falling back to `origin/main`)
 - [x] Attempt automatic resolutions (use `f2clipboard merge-resolve`)
 - [x] Strategy A – merge with `-X ours` and run checks (`f2clipboard merge-resolve --strategy ours`)
   - [x] `pre-commit run --files <modified_files>` (use `f2clipboard merge-checks`)

--- a/f2clipboard/merge_resolve.py
+++ b/f2clipboard/merge_resolve.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 from enum import Enum
 from pathlib import Path
 
+import click
+import httpx
 import typer
+from click.core import ParameterSource
 
+from .config import Settings
 from .merge_checks import merge_checks_command
+
+GITHUB_API = "https://api.github.com"
+PR_BRANCH_PREFIX = "pr-"
 
 
 class MergeStrategy(str, Enum):
@@ -80,9 +88,122 @@ def _attempt_merge(repo: Path, base: str, strategy: MergeStrategy) -> bool:
     return False
 
 
+def _parse_pr_identifier(pr_value: str) -> tuple[int, str | None, str | None]:
+    """Return PR number and optional owner/repo parsed from *pr_value*."""
+
+    pr_value = pr_value.strip()
+    if pr_value.isdigit():
+        return int(pr_value), None, None
+
+    match = re.match(
+        r"https?://github.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)",
+        pr_value,
+    )
+    if match:
+        return (
+            int(match.group("number")),
+            match.group("owner"),
+            match.group("repo"),
+        )
+
+    raise ValueError("Provide a PR number or GitHub pull request URL")
+
+
+def _get_remote_slug(repo: Path) -> tuple[str, str]:
+    """Return ``(owner, repo)`` derived from the origin remote URL."""
+
+    result = subprocess.run(
+        ["git", "config", "--get", "remote.origin.url"],
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or "Could not read origin remote URL"
+        raise RuntimeError(message)
+
+    url = result.stdout.strip()
+    if not url:
+        raise RuntimeError("origin remote URL is empty")
+
+    if url.startswith("git@"):
+        path = url.split(":", 1)[-1]
+    elif "github.com/" in url:
+        path = url.split("github.com/", 1)[-1]
+    else:
+        raise RuntimeError("Unsupported origin remote URL format")
+
+    if path.endswith(".git"):
+        path = path[:-4]
+
+    owner, _, repo_name = path.partition("/")
+    if not owner or not repo_name:
+        raise RuntimeError("Could not parse origin remote into owner/repo")
+
+    return owner, repo_name
+
+
+def _fetch_pr_base(owner: str, repo: str, number: int, token: str | None) -> str | None:
+    """Return the base branch for the PR or ``None`` when unavailable."""
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "f2clipboard",
+    }
+    token = token.strip() if token else None
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        response = httpx.get(
+            f"{GITHUB_API}/repos/{owner}/{repo}/pulls/{number}",
+            headers=headers,
+            timeout=10.0,
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        typer.echo(f"Warning: Failed to fetch PR metadata: {exc}", err=True)
+        return None
+
+    data = response.json()
+    base = data.get("base", {})
+    ref = base.get("ref")
+    return ref or None
+
+
+def _checkout_pr_branch(repo: Path, number: int) -> str:
+    """Fetch the PR head into a local branch and check it out."""
+
+    branch = f"{PR_BRANCH_PREFIX}{number}"
+    fetch = subprocess.run(
+        ["git", "fetch", "--force", "origin", f"pull/{number}/head:{branch}"],
+        cwd=repo,
+    )
+    if fetch.returncode != 0:
+        typer.echo(
+            f"Failed to fetch PR #{number} from origin (exit code {fetch.returncode}).",
+            err=True,
+        )
+        raise typer.Exit(code=fetch.returncode or 1)
+
+    checkout = subprocess.run(["git", "checkout", branch], cwd=repo)
+    if checkout.returncode != 0:
+        typer.echo(
+            f"Failed to check out fetched branch '{branch}' (exit code {checkout.returncode}).",
+            err=True,
+        )
+        raise typer.Exit(code=checkout.returncode or 1)
+
+    return branch
+
+
 def merge_resolve_command(
-    base: str = typer.Option(
-        "origin/main", "--base", "-b", help="Base branch to merge from."
+    base: str | None = typer.Option(
+        None,
+        "--base",
+        "-b",
+        help="Base branch to merge from (defaults to PR base or origin/main).",
     ),
     strategy: MergeStrategy = typer.Option(
         MergeStrategy.ours,
@@ -104,11 +225,49 @@ def merge_resolve_command(
         "--run-checks/--no-run-checks",
         help="Run `f2clipboard merge-checks` after a successful merge.",
     ),
+    pr: str | None = typer.Option(
+        None,
+        "--pr",
+        help="PR number or GitHub pull request URL to fetch and check out before merging.",
+    ),
 ) -> None:
     """Attempt automatic merge conflict resolution strategies."""
 
     repo = repo.resolve()
     _ensure_clean_worktree(repo)
+
+    ctx = click.get_current_context(silent=True)
+    base_provided = False
+    if ctx is not None:
+        base_source = ctx.get_parameter_source("base")
+        base_provided = base_source not in (None, ParameterSource.DEFAULT)
+
+    merge_base = base if base is not None else None
+
+    if pr:
+        try:
+            pr_number, owner, repo_name = _parse_pr_identifier(pr)
+        except ValueError as exc:
+            typer.echo(str(exc), err=True)
+            raise typer.Exit(code=1) from exc
+
+        if owner is None or repo_name is None:
+            try:
+                owner, repo_name = _get_remote_slug(repo)
+            except RuntimeError as exc:
+                typer.echo(str(exc), err=True)
+                raise typer.Exit(code=1) from exc
+
+        settings = Settings()
+        base_ref = _fetch_pr_base(owner, repo_name, pr_number, settings.github_token)
+        branch = _checkout_pr_branch(repo, pr_number)
+        typer.echo(f"Checked out PR #{pr_number} into '{branch}'.")
+        if base_ref and not base_provided:
+            merge_base = f"origin/{base_ref}"
+            typer.echo(f"Using base branch '{merge_base}' from PR metadata.")
+
+    if merge_base is None:
+        merge_base = "origin/main"
 
     strategies: list[MergeStrategy]
     if strategy is MergeStrategy.both:
@@ -118,7 +277,7 @@ def merge_resolve_command(
 
     succeeded: MergeStrategy | None = None
     for current in strategies:
-        if _attempt_merge(repo, base, current):
+        if _attempt_merge(repo, merge_base, current):
             succeeded = current
             break
 


### PR DESCRIPTION
## Summary
- add an optional `--pr` flag to `merge-resolve` that fetches the pull request head, checks it out into a local `pr-<number>` branch, and uses GitHub metadata to set the merge base when available
- refresh the merge conflict roadmap and README to document the automated PR preparation workflow
- extend the merge-resolve test suite with coverage for PR fetching, metadata usage, and base-override behaviour

## Testing
- pre-commit run --files README.md docs/merge-conflict-roadmap.md f2clipboard/merge_resolve.py tests/test_merge_resolve.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df7d4f5770832f97446303f0ba13e7