### PR TITLE
✨ : – post merge-resolve PR outcome comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,9 @@ The command fetches the PR's head (`pull/<number>/head`), checks it out into a
 local `pr-<number>` branch, looks up the base branch from the GitHub API, and
 then attempts the requested merge strategy (or both). It also ensures the
 working tree is clean and by default runs `f2clipboard merge-checks` after a
-successful merge. Pass `--no-run-checks` to skip automated validation, use
+successful merge. When `--pr` is provided and `GITHUB_TOKEN` is configured the
+tool also posts a summary comment to the pull request describing the outcome.
+Pass `--no-run-checks` to skip automated validation, use
 `--strategy ours`/`--strategy theirs` to attempt a single strategy, or override
 the merge base with `--base`.
 

--- a/docs/merge-conflict-roadmap.md
+++ b/docs/merge-conflict-roadmap.md
@@ -17,4 +17,4 @@ This checklist captures the workflow for resolving merge conflicts in pull reque
   - [ ] Collect conflicting hunks: `git --no-pager diff --name-only --diff-filter=U`
   - [ ] Use the Codex merge-conflicts prompt to generate a patch
   - [ ] Apply the patch and rerun checks
-- [ ] Post a PR comment summarizing the outcome (strategy used or need for manual review)
+- [x] Post a PR comment summarizing the outcome (strategy used or need for manual review)


### PR DESCRIPTION
## Summary
- add GitHub PR comment posting to merge-resolve when invoked with --pr
- warn when authentication is missing and document the new behaviour
- cover the new workflow with targeted tests and mark the roadmap item complete

## Testing
- pre-commit run --files README.md docs/merge-conflict-roadmap.md f2clipboard/merge_resolve.py tests/test_merge_resolve.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1b6604b40832f94328dc4de6c0eea