### PR TITLE
feat: suggest merge patch after failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,13 @@ Pass `--no-run-checks` to skip automated validation, use
 `--strategy ours`/`--strategy theirs` to attempt a single strategy, or override
 the merge base with `--base`.
 
+If all merge strategies fail, the command gathers the conflicting hunks and,
+when either `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` is configured, invokes the
+Codex merge-conflicts prompt to propose a unified diff. The suggested patch is
+printed to stdout so you can review or apply it with `git apply`. Without
+credentials the command reminds you to configure an API key for automatic patch
+generation.
+
 Run the standard checks after resolving conflicts:
 
 ```bash

--- a/docs/merge-conflict-roadmap.md
+++ b/docs/merge-conflict-roadmap.md
@@ -15,6 +15,6 @@ This checklist captures the workflow for resolving merge conflicts in pull reque
   - [x] `pytest -q` (covered by `f2clipboard merge-checks`)
 - [ ] If both strategies fail
   - [ ] Collect conflicting hunks: `git --no-pager diff --name-only --diff-filter=U`
-  - [ ] Use the Codex merge-conflicts prompt to generate a patch
+  - [x] Use the Codex merge-conflicts prompt to generate a patch 💯
   - [ ] Apply the patch and rerun checks
 - [x] Post a PR comment summarizing the outcome (strategy used or need for manual review)


### PR DESCRIPTION
What:
- call the Codex merge-conflicts prompt when merge-resolve strategies fail
- surface the suggested diff, update docs, and cover the flow with tests

Why:
- README and roadmap promised patch generation after failed strategies

How to test:
- pre-commit run --files README.md docs/merge-conflict-roadmap.md f2clipboard/llm.py f2clipboard/merge_resolve.py tests/test_merge_resolve.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e312f8f79c832f96f414e48d361970