### PR TITLE
✨ Apply LLM merge patches automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,10 +261,12 @@ the merge base with `--base`.
 
 If all merge strategies fail, the command gathers the conflicting hunks and,
 when either `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` is configured, invokes the
-Codex merge-conflicts prompt to propose a unified diff. The suggested patch is
-printed to stdout so you can review or apply it with `git apply`. Without
-credentials the command reminds you to configure an API key for automatic patch
-generation.
+Codex merge-conflicts prompt to propose a unified diff. `merge-resolve` then
+retries the merge, applies the suggested patch automatically and stages the
+changes before running `f2clipboard merge-checks` (unless `--no-run-checks` is
+provided). If the patch cannot be applied it is printed so you can review or
+apply it manually. Without credentials the command reminds you to configure an
+API key for automatic patch generation.
 
 Run the standard checks after resolving conflicts:
 

--- a/docs/merge-conflict-roadmap.md
+++ b/docs/merge-conflict-roadmap.md
@@ -16,5 +16,5 @@ This checklist captures the workflow for resolving merge conflicts in pull reque
 - [ ] If both strategies fail
   - [ ] Collect conflicting hunks: `git --no-pager diff --name-only --diff-filter=U`
   - [x] Use the Codex merge-conflicts prompt to generate a patch 💯
-  - [ ] Apply the patch and rerun checks
+  - [x] Apply the patch automatically and rerun checks
 - [x] Post a PR comment summarizing the outcome (strategy used or need for manual review)


### PR DESCRIPTION
## Summary
- auto-apply generated merge patches when automatic strategies fail, staging the result for review
- adjust merge-resolve PR comments and roadmap/docs to describe the new behaviour
- extend the merge-resolve test suite for patch success, failure, and messaging paths

## Testing
- pre-commit run --files README.md docs/merge-conflict-roadmap.md f2clipboard/merge_resolve.py tests/test_merge_resolve.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e409bf1f64832f88c50bb7f3718045